### PR TITLE
Convert weight from lbs to kgs

### DIFF
--- a/custom_components/bodymiscale/__init__.py
+++ b/custom_components/bodymiscale/__init__.py
@@ -58,6 +58,8 @@ from custom_components.bodymiscale.const import (
     ATTR_BODY,
     ATTR_BODY_SCORE,
     ATTR_METABOLIC,
+    ATTR_UNIT_OF_MEASUREMENT,
+    UNIT_POUNDS,
     DEFAULT_NAME,
     ATTR_PROBLEM,
     ATTR_SENSORS,
@@ -178,6 +180,8 @@ class Bodymiscale(Entity):
         if reading == READING_WEIGHT:
             if value != STATE_UNAVAILABLE:
                 value = float(value)
+            if new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UNIT_POUNDS:
+                value = value * 0.45359237
             self._weight = value
         elif reading == READING_IMPEDANCE:
             if value != STATE_UNAVAILABLE:

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -43,6 +43,8 @@ ATTR_PROTEIN = "protein"
 ATTR_BODY = "body_type"
 ATTR_BODY_SCORE = "body_score"
 ATTR_METABOLIC = "metabolic_age"
+ATTR_UNIT_OF_MEASUREMENT = "unit_of_measurement"
+UNIT_POUNDS = "lbs"
 
 # Defaults
 DEFAULT_NAME = "bodymiscale"


### PR DESCRIPTION
This just checks if the scale is set to report in pounds, and converts the value to kilograms if needed, so the body composition calculations will work.