### PR TITLE
remove yaml support + fix config flow options

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,33 @@
 {
-  "name": "Bodymiscale Development",
-  "image": "ghcr.io/ludeeus/devcontainer/integration:stable",
-  "postCreateCommand": "container install && pip install --ignore-installed -r requirements.txt",
-  "context": "..",
   "appPort": ["9123:8123"],
+  "context": "..",
   "extensions": [
     "ms-python.python",
     "github.vscode-pull-request-github",
     "ryanluker.vscode-coverage-gutters",
     "ms-python.vscode-pylance"
   ],
+  "image": "ghcr.io/ludeeus/devcontainer/integration:stable",
+  "name": "Bodymiscale Development",
+  "postCreateCommand": "container install && pip install --ignore-installed -r requirements.txt",
   "settings": {
-    "files.eol": "\n",
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
     "editor.tabSize": 4,
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "python.analysis.autoSearchPaths": false,
+    "python.formatting.provider": "black",
+    "python.linting.enabled": true,
+    "python.linting.pylintArgs": ["--disable", "import-error"],
+    "python.linting.pylintEnabled": true,
+    "python.pythonPath": "/usr/local/python/bin/python",
+    "terminal.integrated.defaultProfile.linux": "zsh",
     "terminal.integrated.profiles.linux": {
       "zsh": {
         "path": "/usr/bin/zsh"
       }
-    },
-    "terminal.integrated.defaultProfile.linux": "zsh",
-    "python.pythonPath": "/usr/local/python/bin/python",
-    "python.analysis.autoSearchPaths": false,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.linting.pylintArgs": ["--disable", "import-error"],
-    "python.formatting.provider": "black",
-    "editor.formatOnPaste": false,
-    "editor.formatOnSave": true,
-    "editor.formatOnType": true,
-    "files.trimTrailingWhitespace": true
+    }
   }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,11 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    labels:
-      - "pr: dependency-update"
     schedule:
       interval: "daily"
 
   # Maintain dependencies for pip
   - package-ecosystem: "pip"
     directory: "/"
-    labels:
-      - "pr: dependency-update"
     schedule:
       interval: "daily"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,12 @@ repos:
       - id: detect-private-key
       - id: no-commit-to-branch
       - id: requirements-txt-fixer
+      - id: pretty-format-json
+        args:
+          - --autofix
+          - --no-ensure-ascii
+          - --top-keys=domain,name,version
+        exclude: \.(devcontainer|vscode)
       - id: mixed-line-ending
         args:
           - --fix=lf
@@ -56,6 +62,9 @@ repos:
     rev: v2.6.2
     hooks:
       - id: prettier
+        exclude_types:
+          - json
+          - python
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,12 +48,6 @@ repos:
       - id: detect-private-key
       - id: no-commit-to-branch
       - id: requirements-txt-fixer
-      - id: pretty-format-json
-        args:
-          - --autofix
-          - --no-ensure-ascii
-          - --top-keys=domain,name,version
-        exclude: \.(devcontainer|vscode)
       - id: mixed-line-ending
         args:
           - --fix=lf
@@ -62,8 +56,10 @@ repos:
     rev: v2.6.2
     hooks:
       - id: prettier
+        additional_dependencies:
+          - prettier@2.6.2
+          - prettier-plugin-sort-json@0.0.2
         exclude_types:
-          - json
           - python
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "jsonRecursiveSort": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "python.pythonPath": "/usr/local/bin/python",
   "files.associations": {
     "*.yaml": "home-assistant"
-  }
+  },
+  "python.linting.enabled": true,
+  "python.linting.pylintEnabled": true,
+  "python.pythonPath": "/usr/local/bin/python"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,29 +1,29 @@
 {
-  "version": "2.0.0",
   "tasks": [
     {
-      "label": "Run Home Assistant on port 9123",
-      "type": "shell",
       "command": "container start",
-      "problemMatcher": []
+      "label": "Run Home Assistant on port 9123",
+      "problemMatcher": [],
+      "type": "shell"
     },
     {
-      "label": "Run Home Assistant configuration against /config",
-      "type": "shell",
       "command": "container check",
-      "problemMatcher": []
+      "label": "Run Home Assistant configuration against /config",
+      "problemMatcher": [],
+      "type": "shell"
     },
     {
-      "label": "Upgrade Home Assistant to latest dev",
-      "type": "shell",
       "command": "container install",
-      "problemMatcher": []
+      "label": "Upgrade Home Assistant to latest dev",
+      "problemMatcher": [],
+      "type": "shell"
     },
     {
-      "label": "Install a specific version of Home Assistant",
-      "type": "shell",
       "command": "container set-version",
-      "problemMatcher": []
+      "label": "Install a specific version of Home Assistant",
+      "problemMatcher": [],
+      "type": "shell"
     }
-  ]
+  ],
+  "version": "2.0.0"
 }

--- a/custom_components/bodymiscale/__init__.py
+++ b/custom_components/bodymiscale/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from awesomeversion import AwesomeVersion
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_SENSORS, STATE_OK, STATE_PROBLEM
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
@@ -86,38 +86,6 @@ def is_ha_supported() -> bool:
     return False
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up component via yaml."""
-    if DOMAIN in config:
-        if not is_ha_supported():
-            return False
-
-        _LOGGER.warning(
-            "Configuration of the bodymiscale in YAML is deprecated "
-            "and will be removed future versions; Your existing "
-            "configuration has been imported into the UI automatically and can be "
-            "safely removed from your configuration.yaml file"
-        )
-
-        for name, conf in config[DOMAIN].items():
-            conf[CONF_NAME] = name
-            conf[CONF_SENSOR_WEIGHT] = conf[CONF_SENSORS][CONF_SENSOR_WEIGHT]
-            if CONF_SENSOR_IMPEDANCE in conf[CONF_SENSORS]:
-                conf[CONF_SENSOR_IMPEDANCE] = conf[CONF_SENSORS][CONF_SENSOR_IMPEDANCE]
-
-            del conf[CONF_SENSORS]
-
-            conf[CONF_BIRTHDAY] = conf.pop("born")
-
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
-                )
-            )
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component via UI."""
     if not is_ha_supported():
@@ -135,12 +103,63 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = hass.data[DOMAIN][COORDINATORS][
         entry.entry_id
-    ] = BodyScaleCoordinator(hass, entry.data)
+    ] = BodyScaleCoordinator(hass, {**entry.data, **entry.options})
 
-    component = hass.data[DOMAIN][COMPONENT]
+    component: EntityComponent = hass.data[DOMAIN][COMPONENT]
     await component.async_add_entities([Bodymiscale(coordinator)])
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    # Reload entry when its updated.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok: bool = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        component: EntityComponent = hass.data[DOMAIN][COMPONENT]
+        await component.async_prepare_reload()
+
+        del hass.data[DOMAIN][COORDINATORS][entry.entry_id]
+        if len(hass.data[DOMAIN][COORDINATORS]) == 0:
+            hass.data.pop(DOMAIN)
+
+    return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when it changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(_: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %d", config_entry.version)
+
+    if config_entry.version == 1:
+        data = {**config_entry.data}
+        options = {
+            CONF_HEIGHT: data.pop(CONF_HEIGHT),
+            CONF_SENSOR_WEIGHT: data.pop(CONF_SENSOR_WEIGHT),
+        }
+        if CONF_SENSOR_IMPEDANCE in data:
+            options[CONF_SENSOR_IMPEDANCE] = data.pop(CONF_SENSOR_IMPEDANCE)
+
+        if config_entry.options:
+            options.update(config_entry.options)
+            options.pop(CONF_NAME)
+            options.pop(CONF_BIRTHDAY)
+            options.pop(CONF_GENDER)
+
+        config_entry.data = data
+        config_entry.options = options
+
+        config_entry.version = 2
+
+    _LOGGER.info("Migration to version %d successful", config_entry.version)
     return True
 
 

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -1,12 +1,15 @@
 {
   "domain": "bodymiscale",
   "name": "BodyMiScale",
-  "documentation": "https://github.com/dckiller51/bodymiscale",
-  "issue_tracker": "https://github.com/dckiller51/bodymiscale/issues",
-  "dependencies": [],
-  "codeowners": ["@dckiller51", "@edenhaus"],
-  "requirements": [],
-  "iot_class": "calculated",
   "version": "2.1.1",
-  "config_flow": true
+  "codeowners": [
+    "@dckiller51",
+    "@edenhaus"
+  ],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/dckiller51/bodymiscale",
+  "iot_class": "calculated",
+  "issue_tracker": "https://github.com/dckiller51/bodymiscale/issues",
+  "requirements": []
 }

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -1,15 +1,12 @@
 {
-  "domain": "bodymiscale",
-  "name": "BodyMiScale",
-  "version": "2.1.1",
-  "codeowners": [
-    "@dckiller51",
-    "@edenhaus"
-  ],
+  "codeowners": ["@dckiller51", "@edenhaus"],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/dckiller51/bodymiscale",
+  "domain": "bodymiscale",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/dckiller51/bodymiscale/issues",
-  "requirements": []
+  "name": "BodyMiScale",
+  "requirements": [],
+  "version": "2.1.1"
 }

--- a/custom_components/bodymiscale/translations/de.json
+++ b/custom_components/bodymiscale/translations/de.json
@@ -1,19 +1,24 @@
 {
   "config": {
     "error": {
+      "already_configured": "Bereits konfiguriert",
       "invalid_date": "Ungültiges Datum"
     },
     "step": {
-      "user": {
+      "options": {
         "data": {
           "height": "Größe",
-          "birthday": "Geburtstag",
-          "gender": "Geschlecht",
-          "weight": "Gewicht sensor",
-          "impedance": "Impedanz sensor"
+          "impedance": "Impedanz sensor",
+          "weight": "Gewicht sensor"
         },
         "data_description": {
           "impedance": "Falls deine Waage keine Impedanz liefert, lasse dieses Feld leer."
+        }
+      },
+      "user": {
+        "data": {
+          "birthday": "Geburtstag",
+          "gender": "Geschlecht"
         }
       }
     }
@@ -23,8 +28,8 @@
       "init": {
         "data": {
           "height": "Größe",
-          "weight": "Gewicht sensor",
-          "impedance": "Impedanz sensor"
+          "impedance": "Impedanz sensor",
+          "weight": "Gewicht sensor"
         },
         "data_description": {
           "impedance": "Falls deine Waage keine Impedanz liefert, lasse dieses Feld leer."

--- a/custom_components/bodymiscale/translations/en.json
+++ b/custom_components/bodymiscale/translations/en.json
@@ -17,9 +17,9 @@
       },
       "user": {
         "data": {
-          "name": "Name",
           "birthday": "Birthday",
-          "gender": "Gender"
+          "gender": "Gender",
+          "name": "Name"
         }
       }
     }

--- a/custom_components/bodymiscale/translations/en.json
+++ b/custom_components/bodymiscale/translations/en.json
@@ -1,26 +1,25 @@
 {
-  "state": {
-    "_": {
-      "ok": "OK",
-      "problem": "Problem"
-    }
-  },
   "config": {
     "error": {
+      "already_configured": "Already configured",
       "invalid_date": "Invalid date"
     },
     "step": {
-      "user": {
+      "options": {
         "data": {
-          "name": "Name",
           "height": "Height",
-          "birthday": "Birthday",
-          "gender": "Gender",
-          "weight": "Weight sensor",
-          "impedance": "Impedance sensor"
+          "impedance": "Impedance sensor",
+          "weight": "Weight sensor"
         },
         "data_description": {
           "impedance": "If your scale does not provide the impedance, leave this field empty."
+        }
+      },
+      "user": {
+        "data": {
+          "name": "Name",
+          "birthday": "Birthday",
+          "gender": "Gender"
         }
       }
     }
@@ -30,13 +29,19 @@
       "init": {
         "data": {
           "height": "Height",
-          "weight": "Weight sensor",
-          "impedance": "Impedance sensor"
+          "impedance": "Impedance sensor",
+          "weight": "Weight sensor"
         },
         "data_description": {
           "impedance": "If your scale does not provide the impedance, leave this field empty."
         }
       }
+    }
+  },
+  "state": {
+    "_": {
+      "ok": "OK",
+      "problem": "Problem"
     }
   }
 }

--- a/custom_components/bodymiscale/translations/fr.json
+++ b/custom_components/bodymiscale/translations/fr.json
@@ -6,11 +6,11 @@
     "step": {
       "user": {
         "data": {
-          "name": "Nom",
           "birthday": "Anniversaire",
           "gender": "Genre",
           "height": "Taille",
           "impedance": "Capteur d' impédance",
+          "name": "Nom",
           "weight": "Capteur de poids"
         },
         "data_description": {

--- a/custom_components/bodymiscale/translations/fr.json
+++ b/custom_components/bodymiscale/translations/fr.json
@@ -1,10 +1,4 @@
 {
-  "state": {
-    "_": {
-      "ok": "OK",
-      "problem": "Probl\u00e8me"
-    }
-  },
   "config": {
     "error": {
       "invalid_date": "Date non valide"
@@ -13,14 +7,14 @@
       "user": {
         "data": {
           "name": "Nom",
-          "height": "Taille",
           "birthday": "Anniversaire",
           "gender": "Genre",
-          "weight": "Capteur de poids",
-          "impedance": "Capteur d\u0027 imp\u00e9dance"
+          "height": "Taille",
+          "impedance": "Capteur d' impédance",
+          "weight": "Capteur de poids"
         },
         "data_description": {
-          "impedance": "Si votre balance ne fournit pas l\u0027 imp\u00e9dance\u002C laissez ce champ vide."
+          "impedance": "Si votre balance ne fournit pas l' impédance, laissez ce champ vide."
         }
       }
     }
@@ -30,13 +24,19 @@
       "init": {
         "data": {
           "height": "Taille",
-          "weight": "Capteur de poids",
-          "impedance": "Capteur d\u0027 imp\u00e9dance"
+          "impedance": "Capteur d' impédance",
+          "weight": "Capteur de poids"
         },
         "data_description": {
-          "impedance": "Si votre balance ne fournit pas l\u0027 imp\u00e9dance\u002C laissez ce champ vide."
+          "impedance": "Si votre balance ne fournit pas l' impédance, laissez ce champ vide."
         }
       }
+    }
+  },
+  "state": {
+    "_": {
+      "ok": "OK",
+      "problem": "Problème"
     }
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bodymiscale",
   "homeassistant": "2022.4.0b0",
+  "name": "Bodymiscale",
   "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Bodymiscale",
-  "render_readme": true,
-  "homeassistant": "2022.4.0b0"
+  "homeassistant": "2022.4.0b0",
+  "render_readme": true
 }


### PR DESCRIPTION
- Removes the previously deprecated yaml support **BREAKING CHANGE**, therefore I suggest version v3
- Fixes some bug with the config flow:
  - Update entities if we change the setting via Option Handler. Fixes #89 
  - Use values from Options Handler
  - Add "already_configured" error to translations
- Sort all json files

@dckiller51 I would suggest, that we release v3 together with #75, after I have finish it. Takes me probably another week