### PR TITLE
allow input type "input_number" in addition to "sensor"

### DIFF
--- a/custom_components/bodymiscale/config_flow.py
+++ b/custom_components/bodymiscale/config_flow.py
@@ -54,13 +54,13 @@ def _get_options_schema(
                 description={"suggested_value": defaults[CONF_SENSOR_WEIGHT]}
                 if CONF_SENSOR_WEIGHT in defaults
                 else None,
-            ): selector({"entity": {"domain": "sensor"}}),
+            ): selector({"entity": {"domain": ["sensor", "input_number"]}}),
             vol.Optional(
                 CONF_SENSOR_IMPEDANCE,
                 description={"suggested_value": defaults[CONF_SENSOR_IMPEDANCE]}
                 if CONF_SENSOR_IMPEDANCE in defaults
                 else None,
-            ): selector({"entity": {"domain": "sensor"}}),
+            ): selector({"entity": {"domain": ["sensor", "input_number"]}}),
         }
     )
 


### PR DESCRIPTION
Please accept this pull request to allow using "input_number" instead of only "sensor",
this allows for a relatively simple user-selection automation without manually adding custom sensors.
In my case I added "input_number.scale_{user_name}_impedance" and "input_number.scale_{user_name}_weight",
and then created an HA automation with an actionable notification for assigning a new measurement to a specific user,
inspired by your node-red flow.

Here is an example of my automation YAML:

```
alias: Scale user assignment
description: "Create an actionable notification for assigning a new measurement value from mi scale to a specific user"
trigger:
  - platform: state
    entity_id:
      - sensor.ble_impedance_mi_scale
condition: []
action:
  - service: notify.mobile_app_pixel_6
    data:
      message: New weight measurement, please assign user
      data:
        tag: scale
        actions:
          - action: eran
            title: Eran
          - action: lisa
            title: Lisa
    alias: Actionable notification for assigning user to measurement
  - wait_for_trigger:
      - platform: event
        event_type: mobile_app_notification_action
        event_data:
          tag: scale
        alias: Scale user selected
    alias: Wait for a response
  - service: input_number.set_value
    data:
      value: "{{ states('sensor.ble_impedance_mi_scale') | int }}"
    target:
      entity_id: >-
        {{ 'input_number.scale_' + wait.trigger.event.data.action + '_impedance'
        }}
  - service: input_number.set_value
    data:
      value: "{{ states('sensor.ble_stabilized_weight_mi_scale') | float }}"
    target:
      entity_id: "{{ 'input_number.scale_' + wait.trigger.event.data.action + '_weight' }}"
mode: single
```