### PR TITLE
Add age to state attributes

### DIFF
--- a/custom_components/bodymiscale/__init__.py
+++ b/custom_components/bodymiscale/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import StateType
 
 from custom_components.bodymiscale.metrics import BodyScaleMetricsHandler
 from custom_components.bodymiscale.models import Metric
-from custom_components.bodymiscale.util import get_bmi_label, get_ideal_weight, get_age
+from custom_components.bodymiscale.util import get_age, get_bmi_label, get_ideal_weight
 
 from .const import (
     ATTR_AGE,

--- a/custom_components/bodymiscale/__init__.py
+++ b/custom_components/bodymiscale/__init__.py
@@ -19,9 +19,10 @@ from homeassistant.helpers.typing import StateType
 
 from custom_components.bodymiscale.metrics import BodyScaleMetricsHandler
 from custom_components.bodymiscale.models import Metric
-from custom_components.bodymiscale.util import get_bmi_label, get_ideal_weight
+from custom_components.bodymiscale.util import get_bmi_label, get_ideal_weight, get_age
 
 from .const import (
+    ATTR_AGE,
     ATTR_BMILABEL,
     ATTR_FATMASSTOGAIN,
     ATTR_FATMASSTOLOSE,
@@ -214,6 +215,7 @@ class Bodymiscale(BodyScaleBaseEntity):
             CONF_HEIGHT: self._handler.config[CONF_HEIGHT],
             CONF_GENDER: self._handler.config[CONF_GENDER].value,
             ATTR_IDEAL: get_ideal_weight(self._handler.config),
+            ATTR_AGE: get_age(self._handler.config[CONF_BIRTHDAY]),
             **self._available_metrics,
         }
 

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -4,7 +4,6 @@
 import logging
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any, Callable, Optional
 
 from cachetools import TTLCache
@@ -19,6 +18,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import StateType
 
 from custom_components.bodymiscale.metrics.scale import Scale
+from custom_components.bodymiscale.util import get_age
 
 from ..const import (
     CONF_BIRTHDAY,
@@ -117,15 +117,6 @@ _METRIC_DEPS: dict[Metric, MetricInfo] = {
         0,
     ),
 }
-
-
-def _get_age(date: str) -> int:
-    born = datetime.strptime(date, "%Y-%m-%d")
-    today = datetime.today()
-    age = today.year - born.year
-    if (today.month, today.day) < (born.month, born.day):
-        age -= 1
-    return age
 
 
 def _modify_state_for_subscriber(
@@ -296,7 +287,7 @@ class BodyScaleMetricsHandler:
             return
 
         self._available_metrics.setdefault(
-            Metric.AGE, _get_age(self._config[CONF_BIRTHDAY])
+            Metric.AGE, get_age(self._config[CONF_BIRTHDAY])
         )
 
         self._available_metrics[metric] = state

--- a/custom_components/bodymiscale/util.py
+++ b/custom_components/bodymiscale/util.py
@@ -44,6 +44,7 @@ def get_bmi_label(bmi: float) -> str:  # pylint: disable=too-many-return-stateme
         return "Severe obesity"
     return "Massive obesity"
 
+
 def get_age(date: str) -> int:
     born = datetime.strptime(date, "%Y-%m-%d")
     today = datetime.today()

--- a/custom_components/bodymiscale/util.py
+++ b/custom_components/bodymiscale/util.py
@@ -2,6 +2,7 @@
 
 
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from .const import CONF_GENDER, CONF_HEIGHT
@@ -42,3 +43,11 @@ def get_bmi_label(bmi: float) -> str:  # pylint: disable=too-many-return-stateme
     if bmi < 40:
         return "Severe obesity"
     return "Massive obesity"
+
+def get_age(date: str) -> int:
+    born = datetime.strptime(date, "%Y-%m-%d")
+    today = datetime.today()
+    age = today.year - born.year
+    if (today.month, today.day) < (born.month, born.day):
+        age -= 1
+    return age

--- a/custom_components/bodymiscale/util.py
+++ b/custom_components/bodymiscale/util.py
@@ -46,6 +46,7 @@ def get_bmi_label(bmi: float) -> str:  # pylint: disable=too-many-return-stateme
 
 
 def get_age(date: str) -> int:
+    """Get current age from birthdate."""
     born = datetime.strptime(date, "%Y-%m-%d")
     today = datetime.today()
     age = today.year - born.year


### PR DESCRIPTION
As stated in issue #119 , currently the "age" attribute disappears when rebooting Home Assistant and the only way to get it back is reloading the integration (after which it once again disappears on reboot), even when only using one profile. This is also the cause of dckiller51/lovelace-body-miscale-card#38

With this commit I have
- Moved the get_age function to utils
- Added ATTR_AGE to state_attributes

I have left the "get_age" call in "_update_available_metric" function since I'm unsure if that's still necessary,but maybe that can be removed? Especially since this currently gets called for every single metric.