### PR TITLE
add: "weight" device class for weight sensor

### DIFF
--- a/custom_components/bodymiscale/sensor.py
+++ b/custom_components/bodymiscale/sensor.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from typing import Any, Callable, Optional
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -77,6 +78,7 @@ async def async_setup_entry(
                 key=CONF_SENSOR_WEIGHT,
                 icon="mdi:weight-kilogram",
                 native_unit_of_measurement="kg",
+                device_class=SensorDeviceClass.WEIGHT,
             ),
             Metric.WEIGHT,
             lambda _, config: {ATTR_IDEAL: get_ideal_weight(config)},


### PR DESCRIPTION
Did it same way as it's done in withings integration source:
https://github.com/home-assistant/core/blob/07a1a0efa92f838ef8c8336eab344aee48e1913d/homeassistant/components/withings/sensor.py#L56

close #139