### PR TITLE
fix naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ dmypy.json
 .pyre/
 
 .idea
+
+/config

--- a/custom_components/bodymiscale/__init__.py
+++ b/custom_components/bodymiscale/__init__.py
@@ -168,9 +168,7 @@ class Bodymiscale(BodyScaleBaseEntity):
         """Initialize the Bodymiscale component."""
         super().__init__(
             handler,
-            EntityDescription(
-                key="bodymiscale", name=handler.config[CONF_NAME], icon="mdi:human"
-            ),
+            EntityDescription(key="bodymiscale", name=None, icon="mdi:human"),
         )
         self._timer_handle: asyncio.TimerHandle | None = None
         self._available_metrics: MutableMapping[str, StateType] = TTLCache(

--- a/custom_components/bodymiscale/entity.py
+++ b/custom_components/bodymiscale/entity.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.entity import (
     EntityDescription,
 )
 
-from .const import DOMAIN, NAME, VERSION
+from .const import DOMAIN, VERSION
 from .metrics import BodyScaleMetricsHandler
 
 
@@ -49,7 +49,7 @@ class BodyScaleBaseEntity(Entity):  # type: ignore[misc]
         """Return device specific attributes."""
         return DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            name=NAME,
+            name=self._handler.config[CONF_NAME],
             sw_version=VERSION,
             identifiers={(DOMAIN, self._handler.config_entry_id)},
         )

--- a/custom_components/bodymiscale/entity.py
+++ b/custom_components/bodymiscale/entity.py
@@ -2,7 +2,12 @@
 
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
+from homeassistant.helpers.entity import (
+    UNDEFINED,
+    DeviceInfo,
+    Entity,
+    EntityDescription,
+)
 
 from .const import DOMAIN, NAME, VERSION
 from .metrics import BodyScaleMetricsHandler
@@ -12,6 +17,7 @@ class BodyScaleBaseEntity(Entity):  # type: ignore[misc]
     """Body scale base entity."""
 
     _attr_should_poll = False
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -34,13 +40,9 @@ class BodyScaleBaseEntity(Entity):  # type: ignore[misc]
         name = handler.config[CONF_NAME]
         self._attr_unique_id = "_".join([DOMAIN, name, self.entity_description.key])
 
-        if self.entity_description.name:
-            # Name provided, using the provided one
-            if not self.entity_description.name.lower().startswith(name.lower()):
-                # Entity name should start with configurated name
-                self._attr_name = f"{name} {self.entity_description.name}"
-        else:
-            self._attr_name = f"{name} {self.entity_description.key.replace('_', ' ')}"
+        if self.entity_description.name == UNDEFINED:
+            # Name not provided... get it from the key
+            self._attr_name = self.entity_description.key.replace("_", " ").capitalize()
 
     @property
     def device_info(self) -> DeviceInfo | None:

--- a/scripts/develop
+++ b/scripts/develop
@@ -45,16 +45,16 @@ input_number:
 template:
   - sensor:
       - name: Weight
-        state: "{{ states('input_number.weight') }}"
+        state: \"{{ states('input_number.weight') }}\"
         unit_of_measurement: "kg"
       - name: Impedance
-        state: "{{ states('input_number.impedance') }}"
+        state: \"{{ states('input_number.impedance') }}\"
         unit_of_measurement: "ohm"
       - name: Weight 2
-        state: "{{ states('input_number.weight_2') }}"
+        state: \"{{ states('input_number.weight_2') }}\"
         unit_of_measurement: "kg"
       - name: Impedance 2
-        state: "{{ states('input_number.impedance_2') }}"
+        state: \"{{ states('input_number.impedance_2') }}\"
         unit_of_measurement: "ohm"
 
 # If you need to debug uncomment the line below (doc: https://www.home-assistant.io/integrations/debugpy/)


### PR DESCRIPTION
Fixes #173 

The reason is that HA changed the default value of the property `name` from `None` to enum value `UNDEFINED`.
This fix adopts the naming to the new schema, which was introduced a couple release back

@dckiller51 Please test it before merging