### PR TITLE
Indicate that LBM is united as Kilograms and is a weight measure

### DIFF
--- a/custom_components/bodymiscale/sensor.py
+++ b/custom_components/bodymiscale/sensor.py
@@ -100,6 +100,8 @@ async def async_setup_entry(
                     SensorEntityDescription(
                         key=ATTR_LBM,
                         translation_key="lean_body_mass",
+                        native_unit_of_measurement=UnitOfMass.KILOGRAMS,
+                        device_class=SensorDeviceClass.WEIGHT,
                     ),
                     Metric.LBM,
                 ),


### PR DESCRIPTION
LBM is a measure of body mass in units kilograms and should be treated as so. Using this on my installation already so that I can convert to lb in the UI.