### PR TITLE
update last_time on ha side for blueprint

### DIFF
--- a/example_config/weight_impedance_update.yaml
+++ b/example_config/weight_impedance_update.yaml
@@ -18,15 +18,6 @@ blueprint:
           filter:
             domain: sensor
       default: ""
-    last_time_sensor:
-      name: "Last Time Sensor"
-      description: "Select the last time sensor (ESPHome or BLE Monitor)"
-      selector:
-        entity:
-          filter:
-            domain: sensor
-      default: ""
-
     num_users:
       name: "Number of Users"
       description: "Select the number of users to track"
@@ -265,7 +256,6 @@ blueprint:
 variables:
   weight_sensor: !input weight_sensor
   impedance_sensor: !input impedance_sensor
-  last_time_sensor: !input last_time_sensor
   num_users: !input num_users
   users:
     - enabled: true
@@ -314,12 +304,7 @@ action:
   - variables:
       weight: "{{ states(weight_sensor) | float(0) }}"
       impedance: "{{ states(impedance_sensor) | float(0) }}"
-      last_time: >-
-        {% if last_time_sensor != '' and states(last_time_sensor) not in ['unavailable', 'unknown', 'none'] and states(last_time_sensor) is defined %}
-          {{ states(last_time_sensor) | as_datetime | as_local }}
-        {% else %}
-          none
-        {% endif %}
+      last_time: "{{ now() }}"
 
   - condition: template
     value_template: "{{ weight != 0 and weight != 'unknown' and weight != 'unavailable' }}"
@@ -361,7 +346,7 @@ action:
 
         - choose:
             - conditions:
-                - "{{ user_last_time != '' and last_time != none and last_time is defined}}"
+                - "{{ user_last_time != '' }}"
               sequence:
                 - action: input_datetime.set_datetime
                   target:


### PR DESCRIPTION
Previously, the measurement timestamp was reported by the ESP32 device. This change moves timestamp generation to the Home Assistant side, removing the dependency on ESP32 time synchronization.

Benefits:
- Simplifies ESP32 logic
- Avoids potential time drift or mismatch between ESP32 and Home Assistant
- Improves overall reliability of measurement data