### PR TITLE
Add high frequency to blueprint

### DIFF
--- a/example_config/interactive_notification_user_selection_weight_data_update.yaml
+++ b/example_config/interactive_notification_user_selection_weight_data_update.yaml
@@ -55,8 +55,18 @@ blueprint:
           filter:
             domain: sensor
     impedance_sensor:
-      name: Impedance Sensor Entity (Optional)
-      description: The entity ID of your impedance sensor (if available).
+      name: Impedance Sensor Low Frequency Entity (Optional)
+      description: The entity ID of your impedance sensor with 50 kHz (low-frequency) impedance value (if available). Its the sensor with the numerically larger value.
+      # L'ID d'entité de votre capteur d'impédance (si disponible).
+      selector:
+        entity:
+          filter:
+            domain: sensor
+      default: ""
+
+    impedance_high_sensor:
+      name: Impedance High Frequency Sensor Entity (Optional)
+      description: The entity ID of your impedance sensor with 250 kHz (high-frequency) impedance value (if available). Its the sensor with the numerically smaller value (may be named _low).
       # L'ID d'entité de votre capteur d'impédance (si disponible).
       selector:
         entity:
@@ -86,6 +96,15 @@ blueprint:
             domain: input_number
       default: ""
       description: Entity ID of the input_number for User 1's impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 1.
+    user1_impedance_high:
+      name: User 1 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 1's high-frequency impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 1.
     user1_last_time:
       name: User 1 Last Weigh-in (Optional)
@@ -141,6 +160,15 @@ blueprint:
       default: ""
       description: Entity ID of the input_number for User 2's impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 2.
+    user2_impedance_high:
+      name: User 2 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 2's high-frequency impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 2.
     user2_last_time:
       name: User 2 Last Weigh-in (Optional)
       selector:
@@ -194,6 +222,15 @@ blueprint:
             domain: input_number
       default: ""
       description: Entity ID of the input_number for User 3's impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 3.
+    user3_impedance_high:
+      name: User 3 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 3's high-frequency impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 3.
     user3_last_time:
       name: User 3 Last Weigh-in (Optional)
@@ -273,6 +310,15 @@ blueprint:
       default: ""
       description: Entity ID of the input_number for User 4's impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 4.
+    user4_impedance_high:
+      name: User 4 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 4's high-frequency impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 4.
     user4_last_time:
       name: User 4 Last Weigh-in (Optional - Group 2)
       selector:
@@ -327,6 +373,15 @@ blueprint:
             domain: input_number
       default: ""
       description: Entity ID of the input_number for User 5's impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 5.
+    user5_impedance_high:
+      name: User 5 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 5's high-frequency impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 5.
     user5_last_time:
       name: User 5 Last Weigh-in (Optional - Group 2)
@@ -383,6 +438,15 @@ blueprint:
       default: ""
       description: Entity ID of the input_number for User 6's impedance.
       # ID d'entité du input_number pour l'impédance de l'utilisateur 6.
+    user6_impedance_high:
+      name: User 6 Impedance High-Frequency Input Number (Optional)
+      selector:
+        entity:
+          filter:
+            domain: input_number
+      default: ""
+      description: Entity ID of the input_number for User 6's high-frequency impedance.
+      # ID d'entité du input_number pour l'impédance de l'utilisateur 6.
     user6_last_time:
       name: User 6 Last Weigh-in (Optional - Group 2)
       selector:
@@ -418,42 +482,49 @@ variables:
   response_timeout_seconds: !input response_timeout_seconds
   weight_sensor: !input weight_sensor
   impedance_sensor: !input impedance_sensor
+  impedance_high_sensor: !input impedance_high_sensor
   split_weight_threshold: !input split_weight_threshold
   split_weight_direction: !input split_weight_direction
   weight: "{{ states(weight_sensor) | float(0) }}"
   user1_name: !input user1_name
   user1_weight: !input user1_weight
   user1_impedance: !input user1_impedance
+  user1_impedance_high: !input user1_impedance_high
   user1_last_time: !input user1_last_time
   user1_enable_assistance_mode: !input user1_enable_assistance_mode
   user1_source_weight_entity: !input user1_source_weight_entity
   user2_name: !input user2_name
   user2_weight: !input user2_weight
   user2_impedance: !input user2_impedance
+  user2_impedance_high: !input user2_impedance_high
   user2_last_time: !input user2_last_time
   user2_enable_assistance_mode: !input user2_enable_assistance_mode
   user2_source_weight_entity: !input user2_source_weight_entity
   user3_name: !input user3_name
   user3_weight: !input user3_weight
   user3_impedance: !input user3_impedance
+  user3_impedance_high: !input user3_impedance_high
   user3_last_time: !input user3_last_time
   user3_enable_assistance_mode: !input user3_enable_assistance_mode
   user3_source_weight_entity: !input user3_source_weight_entity
   user4_name: !input user4_name
   user4_weight: !input user4_weight
   user4_impedance: !input user4_impedance
+  user4_impedance_high: !input user4_impedance_high
   user4_last_time: !input user4_last_time
   user4_enable_assistance_mode: !input user4_enable_assistance_mode
   user4_source_weight_entity: !input user4_source_weight_entity
   user5_name: !input user5_name
   user5_weight: !input user5_weight
   user5_impedance: !input user5_impedance
+  user5_impedance_high: !input user5_impedance_high
   user5_last_time: !input user5_last_time
   user5_enable_assistance_mode: !input user5_enable_assistance_mode
   user5_source_weight_entity: !input user5_source_weight_entity
   user6_name: !input user6_name
   user6_weight: !input user6_weight
   user6_impedance: !input user6_impedance
+  user6_impedance_high: !input user6_impedance_high
   user6_last_time: !input user6_last_time
   user6_enable_assistance_mode: !input user6_enable_assistance_mode
   user6_source_weight_entity: !input user6_source_weight_entity
@@ -472,6 +543,7 @@ action:
       notification_id: "{{ context.id }}"
       current_weight: "{{ states(weight_sensor) | float(0) }}"
       impedance: "{{ states(impedance_sensor) | float(0) }}"
+      impedance_high: "{{ states(impedance_high_sensor) | float(0) }}"
       group2_condition: >
         {{ (user4_name | string != '' or user5_name | string != '' or user6_name | string != '') and (
             (split_weight_direction == 'below' and current_weight <= split_weight_threshold | float(0)) or
@@ -570,6 +642,16 @@ action:
               - choose:
                   - conditions:
                       - condition: template
+                        value_template: "{{ user1_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user1_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
+              - choose:
+                  - conditions:
+                      - condition: template
                         value_template: "{{ user1_last_time != '' }}"
                     sequence:
                       - action: input_datetime.set_datetime
@@ -603,6 +685,16 @@ action:
                           entity_id: "{{ user2_impedance }}"
                         data:
                           value: "{{ impedance }}"
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ user2_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user2_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -642,6 +734,16 @@ action:
               - choose:
                   - conditions:
                       - condition: template
+                        value_template: "{{ user3_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user3_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
+              - choose:
+                  - conditions:
+                      - condition: template
                         value_template: "{{ user3_last_time != '' }}"
                     sequence:
                       - action: input_datetime.set_datetime
@@ -675,6 +777,16 @@ action:
                           entity_id: "{{ user4_impedance }}"
                         data:
                           value: "{{ impedance }}"
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ user4_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user4_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -714,6 +826,16 @@ action:
               - choose:
                   - conditions:
                       - condition: template
+                        value_template: "{{ user5_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user5_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
+              - choose:
+                  - conditions:
+                      - condition: template
                         value_template: "{{ user5_last_time != '' }}"
                     sequence:
                       - action: input_datetime.set_datetime
@@ -747,6 +869,16 @@ action:
                           entity_id: "{{ user6_impedance }}"
                         data:
                           value: "{{ impedance }}"
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ user6_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                    sequence:
+                      - action: input_number.set_value
+                        target:
+                          entity_id: "{{ user6_impedance_high }}"
+                        data:
+                          value: "{{ impedance_high }}"
               - choose:
                   - conditions:
                       - condition: template

--- a/example_config/interactive_notification_user_selection_weight_data_update.yaml
+++ b/example_config/interactive_notification_user_selection_weight_data_update.yaml
@@ -46,6 +46,19 @@ blueprint:
           unit_of_measurement: seconds
       description: The number of seconds to wait for a response to the interactive notification.
       # Le nombre de secondes à attendre pour une réponse à la notification interactive
+    impedance_mode:
+      name: Impedance Mode
+      description: "Select 'No Impedance' to make all impedance fields optional."
+      default: "none"
+      selector:
+        select:
+          options:
+            - label: "No Impedance (Weight only)"
+              value: "none"
+            - label: "Single-frequency (Standard)"
+              value: "standard"
+            - label: "Dual-frequency (S400)"
+              value: "dual_frequency"
     weight_sensor:
       name: Weight Sensor Entity
       description: The entity ID of your weight sensor.
@@ -480,9 +493,10 @@ variables:
   title_notify: !input title_notify
   message_notify: !input message_notify
   response_timeout_seconds: !input response_timeout_seconds
+  mode: !input impedance_mode
   weight_sensor: !input weight_sensor
-  impedance_sensor: !input impedance_sensor
-  impedance_high_sensor: !input impedance_high_sensor
+  z1_entity: !input impedance_sensor
+  z2_entity: !input impedance_high_sensor
   split_weight_threshold: !input split_weight_threshold
   split_weight_direction: !input split_weight_direction
   weight: "{{ states(weight_sensor) | float(0) }}"
@@ -532,6 +546,23 @@ variables:
   has_group2_users_configured: >
     {{ user4_name != '' or user5_name != '' or user6_name != '' }}
 
+  # Logic to determine if impedance data is available
+  has_z1: "{{ z1_entity != '' and states(z1_entity) not in ['unavailable', 'unknown'] }}"
+  has_z2: "{{ z2_entity != '' and states(z2_entity) not in ['unavailable', 'unknown'] }}"
+
+  # Min/Max safety only if both sensors are present for S400
+  impedance_lf: >
+    {% if mode == 'dual_frequency' and has_z1 and has_z2 %}
+      {{ [states(z1_entity)|float, states(z2_entity)|float] | max }}
+    {% elif has_z1 %}
+      {{ states(z1_entity)|float }}
+    {% else %} 0 {% endif %}
+    
+  impedance_hf: >
+    {% if mode == 'dual_frequency' and has_z1 and has_z2 %}
+      {{ [states(z1_entity)|float, states(z2_entity)|float] | min }}
+    {% else %} 0 {% endif %}
+
 trigger:
   - trigger: state
     entity_id: !input weight_sensor
@@ -542,8 +573,8 @@ action:
   - variables:
       notification_id: "{{ context.id }}"
       current_weight: "{{ states(weight_sensor) | float(0) }}"
-      impedance: "{{ states(impedance_sensor) | float(0) }}"
-      impedance_high: "{{ states(impedance_high_sensor) | float(0) }}"
+      computed_z_lf: "{{ impedance_lf }}"
+      computed_z_hf: "{{ impedance_hf }}"
       group2_condition: >
         {{ (user4_name | string != '' or user5_name | string != '' or user6_name | string != '') and (
             (split_weight_direction == 'below' and current_weight <= split_weight_threshold | float(0)) or
@@ -632,23 +663,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user1_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user1_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user1_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user1_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user1_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user1_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -678,23 +709,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user2_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user2_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user2_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user2_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user2_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user2_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -724,23 +755,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user3_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user3_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user3_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user3_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user3_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user3_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -770,23 +801,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user4_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user4_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user4_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user4_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user4_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user4_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -816,23 +847,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user5_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user5_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user5_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user5_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user5_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user5_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -862,23 +893,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user6_impedance != '' and impedance_sensor is defined and impedance_sensor != '' and states(impedance_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user6_impedance != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user6_impedance }}"
                         data:
-                          value: "{{ impedance }}"
+                          value: "{{ computed_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ user6_impedance_high != '' and impedance_high_sensor is defined and impedance_high_sensor != '' and states(impedance_high_sensor) not in ['unavailable', 'unknown'] }}"
+                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user6_impedance_high != '' }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user6_impedance_high }}"
                         data:
-                          value: "{{ impedance_high }}"
+                          value: "{{ computed_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template

--- a/example_config/interactive_notification_user_selection_weight_data_update.yaml
+++ b/example_config/interactive_notification_user_selection_weight_data_update.yaml
@@ -55,7 +55,7 @@ blueprint:
           filter:
             domain: sensor
     impedance_sensor:
-      name: Impedance Sensor Low Frequency Entity (Optional)
+      name: Impedance Low Frequency Sensor Entity (Optional)
       description: The entity ID of your impedance sensor with 50 kHz (low-frequency) impedance value (if available). Its the sensor with the numerically larger value.
       # L'ID d'entité de votre capteur d'impédance (si disponible).
       selector:

--- a/example_config/interactive_notification_user_selection_weight_data_update.yaml
+++ b/example_config/interactive_notification_user_selection_weight_data_update.yaml
@@ -46,19 +46,6 @@ blueprint:
           unit_of_measurement: seconds
       description: The number of seconds to wait for a response to the interactive notification.
       # Le nombre de secondes à attendre pour une réponse à la notification interactive
-    impedance_mode:
-      name: Impedance Mode
-      description: "Select 'No Impedance' to make all impedance fields optional."
-      default: "none"
-      selector:
-        select:
-          options:
-            - label: "No Impedance (Weight only)"
-              value: "none"
-            - label: "Single-frequency (Standard)"
-              value: "standard"
-            - label: "Dual-frequency (S400)"
-              value: "dual_frequency"
     weight_sensor:
       name: Weight Sensor Entity
       description: The entity ID of your weight sensor.
@@ -493,7 +480,6 @@ variables:
   title_notify: !input title_notify
   message_notify: !input message_notify
   response_timeout_seconds: !input response_timeout_seconds
-  mode: !input impedance_mode
   weight_sensor: !input weight_sensor
   z1_entity: !input impedance_sensor
   z2_entity: !input impedance_high_sensor
@@ -550,17 +536,25 @@ variables:
   has_z1: "{{ z1_entity != '' and states(z1_entity) not in ['unavailable', 'unknown'] }}"
   has_z2: "{{ z2_entity != '' and states(z2_entity) not in ['unavailable', 'unknown'] }}"
 
+  # Checking for freshness (to avoid using yesterday's measurement)
+  z1_is_fresh: "{{ has_z1 and (as_timestamp(now()) - as_timestamp(states[z1_entity].last_updated) < 30) }}"
+  z2_is_fresh: "{{ has_z2 and (as_timestamp(now()) - as_timestamp(states[z2_entity].last_updated) < 30) }}"
+
+  # Raw values ​​are retrieved only if they are recent
+  val_z1: "{{ states(z1_entity) | float(0) if z1_is_fresh else 0 }}"
+  val_z2: "{{ states(z2_entity) | float(0) if z2_is_fresh else 0 }}"
+
   # Min/Max safety only if both sensors are present for S400
-  impedance_lf: >
-    {% if mode == 'dual_frequency' and has_z1 and has_z2 %}
-      {{ [states(z1_entity)|float, states(z2_entity)|float] | max }}
-    {% elif has_z1 %}
-      {{ states(z1_entity)|float }}
+  final_z_lf: >
+    {% if val_z1 > 0 and val_z2 > 0 %}
+      {{ [val_z1, val_z2] | max }}
+    {% elif val_z1 > 0 %}
+      {{ val_z1 }}
     {% else %} 0 {% endif %}
 
-  impedance_hf: >
-    {% if mode == 'dual_frequency' and has_z1 and has_z2 %}
-      {{ [states(z1_entity)|float, states(z2_entity)|float] | min }}
+  final_z_hf: >
+    {% if val_z1 > 0 and val_z2 > 0 %}
+      {{ [val_z1, val_z2] | min }}
     {% else %} 0 {% endif %}
 
 trigger:
@@ -573,8 +567,6 @@ action:
   - variables:
       notification_id: "{{ context.id }}"
       current_weight: "{{ states(weight_sensor) | float(0) }}"
-      computed_z_lf: "{{ impedance_lf }}"
-      computed_z_hf: "{{ impedance_hf }}"
       group2_condition: >
         {{ (user4_name | string != '' or user5_name | string != '' or user6_name | string != '') and (
             (split_weight_direction == 'below' and current_weight <= split_weight_threshold | float(0)) or
@@ -651,9 +643,9 @@ action:
               - variables:
                   final_weight_user1: >
                     {% if user1_enable_assistance_mode and user1_source_weight_entity is defined and states(user1_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user1_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user1_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -663,23 +655,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user1_impedance != '' }}"
+                        value_template: "{{ user1_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user1_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user1_impedance_high != '' }}"
+                        value_template: "{{ user1_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user1_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -697,9 +689,9 @@ action:
               - variables:
                   final_weight_user2: >
                     {% if user2_enable_assistance_mode and user2_source_weight_entity is defined and states(user2_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user2_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user2_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -709,23 +701,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user2_impedance != '' }}"
+                        value_template: "{{ user2_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user2_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user2_impedance_high != '' }}"
+                        value_template: "{{ user2_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user2_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -743,9 +735,9 @@ action:
               - variables:
                   final_weight_user3: >
                     {% if user3_enable_assistance_mode and user3_source_weight_entity is defined and states(user3_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user3_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user3_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -755,23 +747,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user3_impedance != '' }}"
+                        value_template: "{{ user3_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user3_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user3_impedance_high != '' }}"
+                        value_template: "{{ user3_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user3_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -789,9 +781,9 @@ action:
               - variables:
                   final_weight_user4: >
                     {% if user4_enable_assistance_mode and user4_source_weight_entity is defined and states(user4_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user4_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user4_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -801,23 +793,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user4_impedance != '' }}"
+                        value_template: "{{ user4_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user4_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user4_impedance_high != '' }}"
+                        value_template: "{{ user4_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user4_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -835,9 +827,9 @@ action:
               - variables:
                   final_weight_user5: >
                     {% if user5_enable_assistance_mode and user5_source_weight_entity is defined and states(user5_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user5_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user5_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -847,23 +839,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user5_impedance != '' }}"
+                        value_template: "{{ user5_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user5_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user5_impedance_high != '' }}"
+                        value_template: "{{ user5_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user5_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template
@@ -881,9 +873,9 @@ action:
               - variables:
                   final_weight_user6: >
                     {% if user6_enable_assistance_mode and user6_source_weight_entity is defined and states(user6_source_weight_entity) not in ['unavailable', 'unknown'] %}
-                      {{ current_weight - states(user6_source_weight_entity) | float(0) }}
+                      {{ current_weight - states(user6_source_weight_entity) | float(0)| round(2) }}
                     {% else %}
-                      {{ current_weight }}
+                      {{ current_weight | round(2) }}
                     {% endif %}
               - action: input_number.set_value
                 target:
@@ -893,23 +885,23 @@ action:
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode != 'none' and impedance_lf > 0 and user6_impedance != '' }}"
+                        value_template: "{{ user6_impedance != '' and final_z_lf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user6_impedance }}"
                         data:
-                          value: "{{ computed_z_lf }}"
+                          value: "{{ final_z_lf }}"
               - choose:
                   - conditions:
                       - condition: template
-                        value_template: "{{ mode == 'dual_frequency' and computed_z_hf > 0 and user6_impedance_high != '' }}"
+                        value_template: "{{ user6_impedance_high != '' and final_z_hf > 0 }}"
                     sequence:
                       - action: input_number.set_value
                         target:
                           entity_id: "{{ user6_impedance_high }}"
                         data:
-                          value: "{{ computed_z_hf }}"
+                          value: "{{ final_z_hf }}"
               - choose:
                   - conditions:
                       - condition: template

--- a/example_config/interactive_notification_user_selection_weight_data_update.yaml
+++ b/example_config/interactive_notification_user_selection_weight_data_update.yaml
@@ -557,7 +557,7 @@ variables:
     {% elif has_z1 %}
       {{ states(z1_entity)|float }}
     {% else %} 0 {% endif %}
-    
+
   impedance_hf: >
     {% if mode == 'dual_frequency' and has_z1 and has_z2 %}
       {{ [states(z1_entity)|float, states(z2_entity)|float] | min }}


### PR DESCRIPTION
Extended impedance sensor configurations to include high-frequency impedance values for all users, making the blueprint compatible with new dual frequency mode of the integration.
The field descriptions have been clarified which sensors to use, based on the comments about the naming convention mismatch.
This allows to use (optional) high-frequency sensor for all users.