### PR TITLE
fix: set minimum HA 2026.3.0 — hotfix 2026.5.1 (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.5.1
+
+### Bug Fixes
+
+- Set minimum Home Assistant version to **2026.3.0** (Python 3.14 required) [[#374](https://github.com/dckiller51/bodymiscale/issues/374)].
+
 ## 2026.5.0
 
 > 🙏 This release is dedicated to [@mano3m](https://github.com/mano3m), whose PR [#355](https://github.com/dckiller51/bodymiscale/pull/355) was the inspiration and technical foundation for this version — state restoration, Dutch translations, profile ID filtering and weight range filtering. Thank you for this outstanding contribution.

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -2,10 +2,10 @@
 
 from homeassistant.const import Platform
 
-MIN_REQUIRED_HA_VERSION = "2023.9.0"
+MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.5.0"
+VERSION = "2026.5.1"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.5.0"
+  "version": "2026.5.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.5.0"
+version = "2026.5.1"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Home Automation",
 ]
-dependencies = ["homeassistant>=2026.4.3"]
+dependencies = ["homeassistant>=2026.5.0"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## 2026.5.1

### Bug Fixes

- Set minimum Home Assistant version to **2026.3.0** (Python 3.14 required) [[#374](https://github.com/dckiller51/bodymiscale/issues/374)].