### PR TITLE
fix(profile): normalize accents in notify service fuzzy match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.5.2
+
+### Bug Fixes
+
+- Fix notification service resolution failing for devices with accented names (e.g. `Smartphone Frédéric` → `mobile_app_smartphone_frederic`) by applying Unicode NFKD normalization before fuzzy matching in `_resolve_notify_service`.
+
 ## 2026.5.1
 
 ### Bug Fixes

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.5.1"
+VERSION = "2026.5.2"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.5.1"
+  "version": "2026.5.2"
 }

--- a/custom_components/bodymiscale/profile.py
+++ b/custom_components/bodymiscale/profile.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import unicodedata
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Any, cast
@@ -458,7 +459,12 @@ class NotificationCoordinator:
         fragments = set()
         if device.name:
             # Normalise display name the same way the companion app does.
-            normalized = device.name.strip().lower()
+            # Strip accents first (e.g. "Frédéric" → "Frederic") so the result
+            # matches the ASCII service name registered by the companion app.
+            nfkd = unicodedata.normalize("NFKD", device.name.strip())
+            normalized = "".join(
+                c for c in nfkd if not unicodedata.combining(c)
+            ).lower()
             for ch in (" ", "-", ".", "(", ")"):
                 normalized = normalized.replace(ch, "_")
             # Remove consecutive/trailing underscores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.5.1"
+version = "2026.5.2"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -87,7 +87,8 @@ warn_unreachable = true
 testpaths = ["tests"]
 asyncio_mode = "auto"
 pythonpath = ["."]
-addopts = "-rxf -x -v -l --cov=./ --cov-report=xml"
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+addopts = "-rxf -x -v -l --tb=short --cov=./ --cov-report=xml"
 
 # ============================================================
 # COVERAGE CONFIGURATION


### PR DESCRIPTION
## 2026.5.2

### Bug Fixes

- Fix notification service resolution failing for devices with accented names (e.g. `Smartphone Frédéric` → `mobile_app_smartphone_frederic`) by applying Unicode NFKD normalization before fuzzy matching in `_resolve_notify_service`.