### PR TITLE
release: 2026.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.5.3
+
+> 🙏 Thank you to [@Eskander](https://github.com/Eskander) for contributing the `nearest_weight` profile method — [[#379](https://github.com/dckiller51/bodymiscale/pull/379)].
+
+### 🆕 New features
+
+#### Nearest-weight profile method
+
+- New `nearest_weight` profile method — automatically assigns a measurement to the
+  user whose current weight is closest to the sensor value, following the approach
+  proposed in [#11 (comment)](https://github.com/dckiller51/bodymiscale/issues/11#issuecomment-2009918440).
+  Closes [#373](https://github.com/dckiller51/bodymiscale/issues/373).
+- Configurable tolerance (`nearest_tolerance`, default ±5 kg) — measurement is
+  rejected if no user's current weight falls within the tolerance window.
+- `initial_weight` field — seeds the user's current weight on first setup so the
+  filter is operational immediately without waiting for a prior accepted measurement.
+- Tie-breaking: when two users are equidistant, the match is awarded alphabetically.
+
+---
+
+### ⚙️ Changes
+
+#### New constants (`const.py`)
+
+- `PROFILE_METHOD_NEAREST`
+- `CONF_INITIAL_WEIGHT`
+- `CONF_NEAREST_TOLERANCE`
+
+---
+
+### 🔧 Bug fixes
+
+- Fixed `async_step_profile` exceeding pylint branch limit — extracted `_validate_weight`, `_validate_nearest` and `_validate_notify` as module-level helpers.
+
 ## 2026.5.2
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Before installing Bodymiscale, ensure you have the following:
 
 1. **A weight sensor in Home Assistant:** There is no relationship between Bodymiscale and a specific connected scale. Bodymiscale works with any weight sensor integrated into Home Assistant.
 
-   > **New in v2026.5.0:** You can now point Bodymiscale directly at your scale's native weight and impedance sensors — no per-user dedicated sensors required. Bodymiscale handles user identification automatically through one of the methods described in the [Configuration](#configuration) section (interactive notification, weight range, or profile ID).
+   > **New in v2026.5.x:** You can now point Bodymiscale directly at your scale's native weight and impedance sensors — no per-user dedicated sensors required. Bodymiscale handles user identification automatically through one of the methods described in the [Configuration](#configuration) section (interactive notification, weight range, nearest current weight, or profile ID).
 
    If you prefer the traditional approach or need data persistence across restarts, an `input_number` entity remains a robust alternative: its value survives a Home Assistant restart, ensuring Bodymiscale always initialises with a valid weight.
 
@@ -59,7 +59,7 @@ Before installing Bodymiscale, ensure you have the following:
 
 **(Optional) Impedance sensor:**
 
-If you plan to use an impedance sensor for advanced metrics (lean body mass, body fat mass, etc.), make sure an impedance sensor is available in Home Assistant. Since v2026.5.0, the scale's own impedance sensor can be shared across profiles — Bodymiscale assigns the measurement to the correct user automatically.
+If you plan to use an impedance sensor for advanced metrics (lean body mass, body fat mass, etc.), make sure an impedance sensor is available in Home Assistant. Since v2026.5.x, the scale's own impedance sensor can be shared across profiles — Bodymiscale assigns the measurement to the correct user automatically.
 
 **(Optional) Last weigh-in sensor:**
 
@@ -168,14 +168,15 @@ Exclusive to dual-frequency hardware capable of measuring impedance at 50 kHz an
    - **Calculation Mode:** Choose between **Xiaomi (Legacy 2017)** or **Scientific**. The Scientific mode (added in v2026.4.0) provides a more granular approach to body composition for specific profiles.
      > **S400 users:** The S400 dual-frequency engine is activated automatically when you configure two impedance sensors (`impedance_low` + `impedance_high`) and select `Dual-frequency S400` as the `impedance_mode`. It uses its own dedicated clinical formulas regardless of the `calculation_mode` setting.
    - **Gender:** Select your gender (Male/Female).
-   - **User identification method** _(new in v2026.5.0)_: Choose how Bodymiscale determines which user to assign a measurement to when using the scale's native sensors:
+   - **User identification method** _(new in v2026.5.x)_: Choose how Bodymiscale determines which user to assign a measurement to when using the scale's native sensors:
      - **Weight range:** Each user is assigned a weight interval (e.g. 60–75 kg). Bodymiscale routes the measurement automatically.
+     - **Nearest current weight:** Bodymiscale assigns the measurement to the user whose last known weight is closest to the measured value. A configurable tolerance window (default ±5 kg) ensures the measurement is rejected if no user is close enough. An initial weight must be provided at setup so the filter is operational from the very first weighing.
      - **Interactive push notification:** After each weighing, a notification is sent to a chosen mobile device. The user taps their name to confirm the measurement.
      - **Profile ID:** For recent scales (e.g. Xiaomi S400 via Xiaomi Home) that broadcast a user slot ID — Bodymiscale matches it directly with no extra step.
      - **None — manual assignment:** No automatic identification. Use this if each person still has their own dedicated sensors.
 4. **Select your weight sensor:** Choose the existing weight sensor in Home Assistant (e.g., a `sensor`, or an `input_number`).
-   Since v2026.5.0, you can select the scale's shared native sensor directly. If you prefer data persistence across restarts, an `input_number` entity is still a solid choice.
-5. **Impedance sensor (optional):** If you have an impedance sensor, select it here. Since v2026.5.0, the scale's own sensor can be shared across profiles. This sensor is required to calculate advanced metrics (lean body mass, body fat mass, etc.).
+   Since v2026.5.x, you can select the scale's shared native sensor directly. If you prefer data persistence across restarts, an `input_number` entity is still a solid choice.
+5. **Impedance sensor (optional):** If you have an impedance sensor, select it here. Since v2026.5.x, the scale's own sensor can be shared across profiles. This sensor is required to calculate advanced metrics (lean body mass, body fat mass, etc.).
 6. **Last measurement time sensor (optional):**
    If you have a last weigh-in sensor, select it here (e.g., a `sensor`, or an `input_datetime`). This sensor is used to record the date and time of the most recent measurement.
 7. Click "Save".
@@ -184,7 +185,7 @@ Exclusive to dual-frequency hardware capable of measuring impedance at 50 kHz an
 
 - **First Name/Identifier:** This field is important because it allows you to personalise the integration and avoid conflicts if multiple people use Bodymiscale in your home. The name you choose will be used to name the entities created by the integration (e.g., `sensor.firstname_weight`, `sensor.firstname_bmi`, etc.).
 - **Date of Birth and Gender:** This information is needed to calculate some metrics, such as basal metabolism.
-- **User identification method:** Since v2026.5.0, Bodymiscale can share the scale's native sensors across multiple profiles and route each measurement to the right user automatically — no per-user dedicated sensors needed.
+- **User identification method:** Since v2026.5.x, Bodymiscale can share the scale's native sensors across multiple profiles and route each measurement to the right user automatically — no per-user dedicated sensors needed. The `nearest_weight` method is a good fit for households where each person's weight is sufficiently distinct and stable.
 
 **Tips:**
 
@@ -200,7 +201,7 @@ Exclusive to dual-frequency hardware capable of measuring impedance at 50 kHz an
 
 ## Data Persistence & Multi-user Management
 
-Since v2026.5.0, multi-user management no longer requires per-user dedicated sensors. Bodymiscale assigns measurements to the correct profile using the identification method configured for each user (weight range, interactive notification, or profile ID).
+Since v2026.5.x, multi-user management no longer requires per-user dedicated sensors. Bodymiscale assigns measurements to the correct profile using the identification method configured for each user (weight range, nearest current weight, interactive notification, or profile ID).
 
 For detailed configuration examples, please refer to the [example_config README](example_config/README_EXAMPLE_CONFIG.md).
 

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.5.2"
+VERSION = "2026.5.3"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.5.2"
+  "version": "2026.5.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.5.2"
+version = "2026.5.3"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## 2026.5.3

> 🙏 Thank you to [@Eskander](https://github.com/Eskander) for contributing the `nearest_weight` profile method — [[#379](https://github.com/dckiller51/bodymiscale/pull/379)].

### 🆕 New features

#### Nearest-weight profile method

- New `nearest_weight` profile method — automatically assigns a measurement to the
  user whose current weight is closest to the sensor value, following the approach
  proposed in [#11 (comment)](https://github.com/dckiller51/bodymiscale/issues/11#issuecomment-2009918440).
  Closes [#373](https://github.com/dckiller51/bodymiscale/issues/373).
- Configurable tolerance (`nearest_tolerance`, default ±5 kg) — measurement is
  rejected if no user's current weight falls within the tolerance window.
- `initial_weight` field — seeds the user's current weight on first setup so the
  filter is operational immediately without waiting for a prior accepted measurement.
- Tie-breaking: when two users are equidistant, the match is awarded alphabetically.

---

### ⚙️ Changes

#### New constants (`const.py`)

- `PROFILE_METHOD_NEAREST`
- `CONF_INITIAL_WEIGHT`
- `CONF_NEAREST_TOLERANCE`

---

### 🔧 Bug fixes

- Fixed `async_step_profile` exceeding pylint branch limit — extracted `_validate_weight`, `_validate_nearest` and `_validate_notify` as module-level helpers.