### PR TITLE
fix(entity): restore translation_key resolution for sensor names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.5.5
+
+### 🔧 Bug fixes
+
+- Fixed sensor name translations not being applied in the UI [[#222](https://github.com/dckiller51/bodymiscale/issues/222)] — `_attr_name` was overriding `translation_key` for all entities. The main umbrella entity now sets its name explicitly while normal sensors delegate name resolution to HA via `translation_key`
+
 ## 2026.5.4
 
 ### 🌍 Translations

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.5.4"
+VERSION = "2026.5.5"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]

--- a/custom_components/bodymiscale/entity.py
+++ b/custom_components/bodymiscale/entity.py
@@ -36,10 +36,11 @@ class BodyScaleBaseEntity(Entity):
         name = handler.config[CONF_NAME]
         self._attr_unique_id = "_".join([DOMAIN, name, self.entity_description.key])
 
-        if self.entity_description.name == UNDEFINED:
-            # Name not provided... get it from the key
-            self._attr_name = self.entity_description.key.replace("_", " ").capitalize()
+        if self.entity_description.name is UNDEFINED:
+            # Normal sensor — let HA resolve the name via translation_key
+            pass
         else:
+            # Main umbrella entity — use the profile name directly
             self._attr_name = (
                 self._handler.config[CONF_NAME].replace("_", " ").capitalize()
             )

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.5.4"
+  "version": "2026.5.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.5.4"
+version = "2026.5.5"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## 2026.5.5

### 🔧 Bug fixes

- Fixed sensor name translations not being applied in the UI [[#222](https://github.com/dckiller51/bodymiscale/issues/222)] — `_attr_name` was overriding `translation_key` for all entities. The main umbrella entity now sets its name explicitly while normal sensors delegate name resolution to HA via `translation_key`