### PR TITLE
release: 2026.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
   the weight value is unchanged — timestamp is now also updated when impedance
   is accepted.
   Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+- Fixed renamed `bone_cell_mass` to `bcm` in attributes to match the bodymiscale component attribute name.
 
 ## 2026.5.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
   until all sensors have settled. In dual-frequency mode (S400), this reduces
   three successive recalculations (weight → impedance_low → impedance_high) to
   a single one. Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+- Fixed `last_measurement_time` not refreshing on subsequent measurements when
+  the weight value is unchanged — timestamp is now also updated when impedance
+  is accepted. Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
 
 ## 2026.5.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,16 @@ All notable changes to this project will be documented in this file.
   successive recalculations (e.g. weight → impedance_low → impedance_high
   in dual-frequency mode) to a single one.
   Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
-- Fixed `last_measurement_time` not refreshing on subsequent measurements when
-  the weight value is unchanged — timestamp is now also updated when impedance
-  is accepted.
+- Fixed `last_measurement_time` updating twice per measurement cycle (once on
+  weight, once on impedance) — timestamp is now stamped once in
+  `_on_debounce_elapsed` after all sensors have settled.
   Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
-- Fixed renamed `bone_cell_mass` to `bcm` in attributes to match the bodymiscale component attribute name.
+- Fixed recalculation firing immediately once all configured sensors have
+  reported for the current cycle, instead of always waiting the full debounce
+  window after the last sensor update.
+  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+- Fixed renamed `bone_cell_mass` to `bcm` in attributes to match the
+  bodymiscale component attribute name.
 
 ## 2026.5.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.5.6
+
+### 🔧 Bug fixes
+
+- Fixed redundant recalculations when weight and impedance arrive as separate
+  state updates — a 2-second debounce now delays `_trigger_dependent_recalculation`
+  until all sensors have settled. In dual-frequency mode (S400), this reduces
+  three successive recalculations (weight → impedance_low → impedance_high) to
+  a single one. Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+
 ## 2026.5.5
 
 ### 🔧 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,14 @@ All notable changes to this project will be documented in this file.
   recalculations.
 - Fixed double/redundant recalculations when weight and impedance arrive as
   separate state updates — a `_settling` flag now blocks intermediate
-  recalculations until the debounce window elapses, reducing multiple
-  successive recalculations (e.g. weight → impedance_low → impedance_high
-  in dual-frequency mode) to a single one.
+  recalculations until the debounce window elapses. A 5-second debounce
+  (`RECALCULATION_DEBOUNCE` in `const.py`) ensures all sensors (weight,
+  impedance_low, impedance_high) have settled before the single recalculation
+  fires.
   Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
 - Fixed `last_measurement_time` updating twice per measurement cycle (once on
   weight, once on impedance) — timestamp is now stamped once in
   `_on_debounce_elapsed` after all sensors have settled.
-  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
-- Fixed recalculation firing immediately once all configured sensors have
-  reported for the current cycle, instead of always waiting the full debounce
-  window after the last sensor update.
   Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
 - Fixed renamed `bone_cell_mass` to `bcm` in attributes to match the
   bodymiscale component attribute name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Bug fixes
 
-- Fixed redundant recalculations when weight and impedance arrive as separate
-  state updates — a 2-second debounce now delays `_trigger_dependent_recalculation`
-  until all sensors have settled. In dual-frequency mode (S400), this reduces
-  three successive recalculations (weight → impedance_low → impedance_high) to
-  a single one. Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+- Fixed double/redundant recalculations when weight and impedance arrive as
+  separate state updates — a `_settling` flag now blocks intermediate
+  recalculations until the debounce window elapses, reducing multiple
+  successive recalculations (e.g. weight → impedance_low → impedance_high
+  in dual-frequency mode) to a single one.
+  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
 - Fixed `last_measurement_time` not refreshing on subsequent measurements when
   the weight value is unchanged — timestamp is now also updated when impedance
-  is accepted. Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
+  is accepted.
+  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
 
 ## 2026.5.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Bug fixes
 
+- Refactored metric recalculation to use topological ordering — all derived
+  metrics are now computed in a single deterministic pass (BMI → LBM →
+  FAT_PERCENTAGE → ... → BODY_SCORE), eliminating redundant cascade
+  recalculations.
 - Fixed double/redundant recalculations when weight and impedance arrive as
   separate state updates — a `_settling` flag now blocks intermediate
   recalculations until the debounce window elapses, reducing multiple

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -146,5 +146,5 @@ PLATFORMS: set[Platform] = {Platform.SENSOR}
 
 # Debounce delays
 # waits for all sensors to settle before recalculating
-RECALCULATION_DEBOUNCE: float = 2.0
+RECALCULATION_DEBOUNCE: float = 5.0
 UPDATE_DELAY: float = 2.0  # waits before writing state to HA

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.5.5"
+VERSION = "2026.5.6"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]
@@ -143,4 +143,8 @@ CONSTRAINT_WEIGHT_MAX = 200
 
 # Home Assistant
 PLATFORMS: set[Platform] = {Platform.SENSOR}
-UPDATE_DELAY = 2.0
+
+# Debounce delays
+# waits for all sensors to settle before recalculating
+RECALCULATION_DEBOUNCE: float = 2.0
+UPDATE_DELAY: float = 2.0  # waits before writing state to HA

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.5.5"
+  "version": "2026.5.6"
 }

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -298,6 +298,7 @@ class BodyScaleMetricsHandler:
         self._pending_timeout_cancel: CALLBACK_TYPE | None = None
         self._debounce_cancel: CALLBACK_TYPE | None = None
         self._settling: bool = False
+        self._received_this_cycle: set[Metric] = set()
 
         # _last_accepted_weight tracks the weight accepted in the current
         # measurement cycle. Used to validate impedance for weight-based
@@ -646,7 +647,7 @@ class BodyScaleMetricsHandler:
 
         # Weight accepted for this cycle — store for impedance validation
         self._last_accepted_weight = val
-        self._schedule_recalculation()
+        self._received_this_cycle = {Metric.WEIGHT}  # reset cycle tracking
         self._update_available_metric(Metric.WEIGHT, val)
 
         return True, None
@@ -700,7 +701,7 @@ class BodyScaleMetricsHandler:
                 _LOGGER.debug("Profile filter rejected impedance: %.2f", val)
                 return False, None
 
-        self._schedule_recalculation()
+        self._received_this_cycle.add(metric)
         self._update_available_metric(metric, val)
 
         return True, None
@@ -829,30 +830,54 @@ class BodyScaleMetricsHandler:
 
         return ordered
 
-    def _schedule_recalculation(self) -> None:
-        """Debounce recalculation — wait for all sensors to settle.
+    def _all_sensors_received(self) -> bool:
+        """Return True when all configured sensors have reported for this cycle."""
+        if Metric.WEIGHT not in self._received_this_cycle:
+            return False
+        if (
+            self._config.get(CONF_SENSOR_IMPEDANCE)
+            and Metric.IMPEDANCE not in self._received_this_cycle
+        ):
+            return False
+        if (
+            self._config.get(CONF_SENSOR_IMPEDANCE_LOW)
+            and Metric.IMPEDANCE_LOW not in self._received_this_cycle
+        ):
+            return False
+        return not (
+            self._config.get(CONF_SENSOR_IMPEDANCE_HIGH)
+            and Metric.IMPEDANCE_HIGH not in self._received_this_cycle
+        )
 
-        Resets the timer on every valid sensor update so the full
-        recalculation only fires once all sensors (weight, impedance_low,
-        impedance_high) have reported their values for this measurement cycle.
+    def _schedule_recalculation(self) -> None:
+        """Trigger recalculation immediately if all sensors have reported.
+
+        Otherwise start a debounce timer to wait for remaining sensors.
         """
         if self._debounce_cancel is not None:
+            _LOGGER.debug("[debounce] Timer cancelled — new sensor value arrived")
             self._debounce_cancel()
             self._debounce_cancel = None
 
         self._settling = True
 
-        self._debounce_cancel = async_call_later(
-            self._hass,
-            RECALCULATION_DEBOUNCE,
-            self._on_debounce_elapsed,
-        )
+        if self._all_sensors_received():
+            _LOGGER.debug("[debounce] All sensors received — firing immediately")
+            self._on_debounce_elapsed(None)
+        else:
+            _LOGGER.debug("[debounce] Waiting for remaining sensors — timer started")
+            self._debounce_cancel = async_call_later(
+                self._hass,
+                RECALCULATION_DEBOUNCE,
+                self._on_debounce_elapsed,
+            )
 
     @callback
     def _on_debounce_elapsed(self, _now: Any) -> None:
         """Fire after the debounce window — all sensors should have settled."""
         self._debounce_cancel = None
         self._settling = False
+        self._received_this_cycle = set()  # close this measurement cycle
         self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, dt_util.utcnow())
         self._trigger_dependent_recalculation()
 

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers.event import async_call_later, async_track_state_change_event
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 
 from ..const import (
     CONF_BIRTHDAY,
@@ -296,6 +297,7 @@ class BodyScaleMetricsHandler:
         self._replaying: bool = False
         self._pending_timeout_cancel: CALLBACK_TYPE | None = None
         self._debounce_cancel: CALLBACK_TYPE | None = None
+        self._settling: bool = False
 
         # _last_accepted_weight tracks the weight accepted in the current
         # measurement cycle. Used to validate impedance for weight-based
@@ -453,7 +455,7 @@ class BodyScaleMetricsHandler:
                     )
                     self._update_available_metric(metric, val)
                 self._pending_impedance.clear()
-            self._trigger_dependent_recalculation()
+            self._schedule_recalculation()
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -642,7 +644,6 @@ class BodyScaleMetricsHandler:
         # Weight accepted for this cycle — store for impedance validation
         self._last_accepted_weight = val
         self._update_available_metric(Metric.WEIGHT, val)
-        self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, state.last_changed)
 
         return True, None
 
@@ -693,9 +694,6 @@ class BodyScaleMetricsHandler:
                 return False, None
 
         self._update_available_metric(metric, val)
-        # Refresh timestamp when impedance is accepted — covers the case where
-        # weight is unchanged between two measurements (no weight state change fired)
-        self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, state.last_changed)
 
         return True, None
 
@@ -770,6 +768,8 @@ class BodyScaleMetricsHandler:
 
     def _recalculate_metric(self, metric: Metric) -> None:
         """Recalculate a single metric if its dependencies are met."""
+        if self._settling:
+            return
         info = self._dependencies.get(metric)
         if info is None:
             return
@@ -803,6 +803,8 @@ class BodyScaleMetricsHandler:
             self._debounce_cancel()
             self._debounce_cancel = None
 
+        self._settling = True
+
         self._debounce_cancel = async_call_later(
             self._hass,
             RECALCULATION_DEBOUNCE,
@@ -813,6 +815,8 @@ class BodyScaleMetricsHandler:
     def _on_debounce_elapsed(self, _now: Any) -> None:
         """Fire after the debounce window — all sensors should have settled."""
         self._debounce_cancel = None
+        self._settling = False
+        self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, dt_util.utcnow())
         self._trigger_dependent_recalculation()
 
     def _trigger_dependent_recalculation(self) -> None:

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -611,8 +611,11 @@ class BodyScaleMetricsHandler:
         if val < CONSTRAINT_WEIGHT_MIN:
             # Scale reset to zero — clear last accepted weight for this cycle
             self._last_accepted_weight = None
+            if val == 0.0:
+                _LOGGER.debug("Weight 0.0 kg — scale reset, ignoring silently")
+                return False, None
             _LOGGER.debug("Weight %.2f kg below minimum — ignoring (scale reset)", val)
-            return False, None
+            return False, "low"
         if val > CONSTRAINT_WEIGHT_MAX:
             return False, "high"
 
@@ -643,6 +646,7 @@ class BodyScaleMetricsHandler:
 
         # Weight accepted for this cycle — store for impedance validation
         self._last_accepted_weight = val
+        self._schedule_recalculation()
         self._update_available_metric(Metric.WEIGHT, val)
 
         return True, None
@@ -664,8 +668,11 @@ class BodyScaleMetricsHandler:
             return False, "invalid_format"
 
         if val < CONSTRAINT_IMPEDANCE_MIN:
-            _LOGGER.debug("Impedance %.2f below minimum — ignoring (scale reset)", val)
-            return False, None
+            if val == 0.0:
+                _LOGGER.debug("Impedance 0.0 — scale reset, ignoring silently")
+                return False, None
+            _LOGGER.debug("Impedance %.2f below minimum — ignoring", val)
+            return False, "low"
         if val > CONSTRAINT_IMPEDANCE_MAX:
             return False, "high"
 
@@ -693,6 +700,7 @@ class BodyScaleMetricsHandler:
                 _LOGGER.debug("Profile filter rejected impedance: %.2f", val)
                 return False, None
 
+        self._schedule_recalculation()
         self._update_available_metric(metric, val)
 
         return True, None
@@ -766,31 +774,60 @@ class BodyScaleMetricsHandler:
             )
         return False
 
-    def _recalculate_metric(self, metric: Metric) -> None:
-        """Recalculate a single metric if its dependencies are met."""
-        if self._settling:
-            return
+    def _can_compute(self, metric: Metric) -> bool:
+        """Return True if all dependencies for this metric are satisfied."""
         info = self._dependencies.get(metric)
         if info is None:
-            return
-
-        # LBM and METABOLIC_AGE require available impedance
+            return False
         if metric in (Metric.LBM, Metric.METABOLIC_AGE):
             if not self._has_impedance():
-                return
+                return False
             if Metric.WEIGHT not in self._available_metrics:
-                return
-            # Check other dependencies (AGE)
+                return False
             other_deps = [d for d in info.depends_on if d is not Metric.IMPEDANCE]
-            if not all(d in self._available_metrics for d in other_deps):
-                return
-        else:
-            if not all(d in self._available_metrics for d in info.depends_on):
-                return
+            return all(d in self._available_metrics for d in other_deps)
+        return all(d in self._available_metrics for d in info.depends_on)
 
+    def _compute_metric(self, metric: Metric) -> None:
+        """Compute a single metric value if dependencies are met and store it."""
+        if not self._can_compute(metric):
+            return
+        info = self._dependencies[metric]
         val = info.calculate(self._config, self._available_metrics)
         if val is not None:
+            _LOGGER.debug("[recalc] %s = %s", metric.name, val)
             self._update_available_metric(metric, val)
+
+    def _topological_order(self) -> list[Metric]:
+        """Return derived metrics in topological order (dependencies before dependents)."""
+        derived = [m for m in _METRIC_DEPS if m not in _SOURCE_METRICS]
+
+        # Kahn's algorithm
+        graph_deps: dict[Metric, list[Metric]] = {}
+        for metric in derived:
+            info = self._dependencies.get(metric)
+            graph_deps[metric] = [
+                d
+                for d in (info.depends_on if info else [])
+                if d in _METRIC_DEPS and d not in _SOURCE_METRICS
+            ]
+
+        in_degree: dict[Metric, int] = {m: len(graph_deps[m]) for m in derived}
+        queue = [m for m, deg in in_degree.items() if deg == 0]
+        ordered: list[Metric] = []
+
+        while queue:
+            metric = queue.pop(0)
+            ordered.append(metric)
+            info = self._dependencies.get(metric)
+            if info:
+                for dependent in info.depended_by:
+                    if dependent in in_degree:
+                        in_degree[dependent] -= 1
+                        if in_degree[dependent] == 0:
+                            queue.append(dependent)
+
+        return ordered
 
     def _schedule_recalculation(self) -> None:
         """Debounce recalculation — wait for all sensors to settle.
@@ -820,12 +857,11 @@ class BodyScaleMetricsHandler:
         self._trigger_dependent_recalculation()
 
     def _trigger_dependent_recalculation(self) -> None:
-        """Recalculate all metrics whose dependencies are now met."""
-        for metric in list(self._available_metrics.keys()):
-            info = self._dependencies.get(metric)
-            if info:
-                for dep in info.depended_by:
-                    self._recalculate_metric(dep)
+        """Recalculate all derived metrics in topological order — one pass, no cascades."""
+        _LOGGER.debug("[recalc] Starting topological recalculation pass")
+        for metric in self._topological_order():
+            self._compute_metric(metric)
+        _LOGGER.debug("[recalc] Topological pass complete")
 
     def _update_available_metric(
         self, metric: Metric, state: StateType | datetime
@@ -851,6 +887,5 @@ class BodyScaleMetricsHandler:
                 for sub in subscribers:
                     sub(sub_state)
 
-            # Trigger recalculation of dependent metrics
-            for dep in info.depended_by:
-                self._recalculate_metric(dep)
+            # Cascade recalculation is handled by _trigger_dependent_recalculation
+            # in topological order — no per-update cascades needed.

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -298,7 +298,6 @@ class BodyScaleMetricsHandler:
         self._pending_timeout_cancel: CALLBACK_TYPE | None = None
         self._debounce_cancel: CALLBACK_TYPE | None = None
         self._settling: bool = False
-        self._received_this_cycle: set[Metric] = set()
 
         # _last_accepted_weight tracks the weight accepted in the current
         # measurement cycle. Used to validate impedance for weight-based
@@ -647,7 +646,7 @@ class BodyScaleMetricsHandler:
 
         # Weight accepted for this cycle — store for impedance validation
         self._last_accepted_weight = val
-        self._received_this_cycle = {Metric.WEIGHT}  # reset cycle tracking
+        self._schedule_recalculation()
         self._update_available_metric(Metric.WEIGHT, val)
 
         return True, None
@@ -701,7 +700,7 @@ class BodyScaleMetricsHandler:
                 _LOGGER.debug("Profile filter rejected impedance: %.2f", val)
                 return False, None
 
-        self._received_this_cycle.add(metric)
+        self._schedule_recalculation()
         self._update_available_metric(metric, val)
 
         return True, None
@@ -830,54 +829,30 @@ class BodyScaleMetricsHandler:
 
         return ordered
 
-    def _all_sensors_received(self) -> bool:
-        """Return True when all configured sensors have reported for this cycle."""
-        if Metric.WEIGHT not in self._received_this_cycle:
-            return False
-        if (
-            self._config.get(CONF_SENSOR_IMPEDANCE)
-            and Metric.IMPEDANCE not in self._received_this_cycle
-        ):
-            return False
-        if (
-            self._config.get(CONF_SENSOR_IMPEDANCE_LOW)
-            and Metric.IMPEDANCE_LOW not in self._received_this_cycle
-        ):
-            return False
-        return not (
-            self._config.get(CONF_SENSOR_IMPEDANCE_HIGH)
-            and Metric.IMPEDANCE_HIGH not in self._received_this_cycle
-        )
-
     def _schedule_recalculation(self) -> None:
-        """Trigger recalculation immediately if all sensors have reported.
+        """Debounce recalculation — wait for all sensors to settle.
 
-        Otherwise start a debounce timer to wait for remaining sensors.
+        Resets the timer on every valid sensor update so the full
+        recalculation only fires once all sensors (weight, impedance_low,
+        impedance_high) have reported their values for this measurement cycle.
         """
         if self._debounce_cancel is not None:
-            _LOGGER.debug("[debounce] Timer cancelled — new sensor value arrived")
             self._debounce_cancel()
             self._debounce_cancel = None
 
         self._settling = True
 
-        if self._all_sensors_received():
-            _LOGGER.debug("[debounce] All sensors received — firing immediately")
-            self._on_debounce_elapsed(None)
-        else:
-            _LOGGER.debug("[debounce] Waiting for remaining sensors — timer started")
-            self._debounce_cancel = async_call_later(
-                self._hass,
-                RECALCULATION_DEBOUNCE,
-                self._on_debounce_elapsed,
-            )
+        self._debounce_cancel = async_call_later(
+            self._hass,
+            RECALCULATION_DEBOUNCE,
+            self._on_debounce_elapsed,
+        )
 
     @callback
     def _on_debounce_elapsed(self, _now: Any) -> None:
         """Fire after the debounce window — all sensors should have settled."""
         self._debounce_cancel = None
         self._settling = False
-        self._received_this_cycle = set()  # close this measurement cycle
         self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, dt_util.utcnow())
         self._trigger_dependent_recalculation()
 

--- a/custom_components/bodymiscale/metrics/__init__.py
+++ b/custom_components/bodymiscale/metrics/__init__.py
@@ -44,6 +44,7 @@ from ..const import (
     PENDING_MEASUREMENT_TIMEOUT,
     PROBLEM_NONE,
     PROFILE_METHOD_NEAREST,
+    RECALCULATION_DEBOUNCE,
     UNIT_POUNDS,
 )
 from ..models import Gender, Metric
@@ -294,6 +295,7 @@ class BodyScaleMetricsHandler:
         self._pending_impedance: dict[Metric, tuple[float, State]] = {}
         self._replaying: bool = False
         self._pending_timeout_cancel: CALLBACK_TYPE | None = None
+        self._debounce_cancel: CALLBACK_TYPE | None = None
 
         # _last_accepted_weight tracks the weight accepted in the current
         # measurement cycle. Used to validate impedance for weight-based
@@ -457,7 +459,10 @@ class BodyScaleMetricsHandler:
 
     @callback
     def unload(self) -> None:
-        """Remove HA listeners and clear subscribers."""
+        """Unload the handler."""
+        if self._debounce_cancel is not None:
+            self._debounce_cancel()
+            self._debounce_cancel = None
         self._cancel_pending_timeout()
 
         if self._remove_listener is not None:
@@ -585,7 +590,7 @@ class BodyScaleMetricsHandler:
             self._clear_sensor_problem(entity_id)
 
         if valid:
-            self._trigger_dependent_recalculation()
+            self._schedule_recalculation()
 
     # ── Process helpers ─────────────────────────────────────────────────────
 
@@ -688,6 +693,9 @@ class BodyScaleMetricsHandler:
                 return False, None
 
         self._update_available_metric(metric, val)
+        # Refresh timestamp when impedance is accepted — covers the case where
+        # weight is unchanged between two measurements (no weight state change fired)
+        self._update_available_metric(Metric.LAST_MEASUREMENT_TIME, state.last_changed)
 
         return True, None
 
@@ -783,6 +791,29 @@ class BodyScaleMetricsHandler:
         val = info.calculate(self._config, self._available_metrics)
         if val is not None:
             self._update_available_metric(metric, val)
+
+    def _schedule_recalculation(self) -> None:
+        """Debounce recalculation — wait for all sensors to settle.
+
+        Resets the timer on every valid sensor update so the full
+        recalculation only fires once all sensors (weight, impedance_low,
+        impedance_high) have reported their values for this measurement cycle.
+        """
+        if self._debounce_cancel is not None:
+            self._debounce_cancel()
+            self._debounce_cancel = None
+
+        self._debounce_cancel = async_call_later(
+            self._hass,
+            RECALCULATION_DEBOUNCE,
+            self._on_debounce_elapsed,
+        )
+
+    @callback
+    def _on_debounce_elapsed(self, _now: Any) -> None:
+        """Fire after the debounce window — all sensors should have settled."""
+        self._debounce_cancel = None
+        self._trigger_dependent_recalculation()
 
     def _trigger_dependent_recalculation(self) -> None:
         """Recalculate all metrics whose dependencies are now met."""

--- a/custom_components/bodymiscale/translations/da.json
+++ b/custom_components/bodymiscale/translations/da.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Alder" },
         "basal_metabolism": { "name": "Basal stofskifte" },
+        "bcm": { "name": "Kropscellemasse" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI klasse",
@@ -128,7 +129,6 @@
             "underweight": "Undervægtig"
           }
         },
-        "body_cell_mass": { "name": "Kropscellemasse" },
         "body_fat": { "name": "Kropsfedt" },
         "body_score": { "name": "Kropsscore" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/de.json
+++ b/custom_components/bodymiscale/translations/de.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Alter" },
         "basal_metabolism": { "name": "Grundumsatz" },
+        "bcm": { "name": "Körperzellmasse" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI Klassifikation",
@@ -128,7 +129,6 @@
             "underweight": "Untergewicht"
           }
         },
-        "body_cell_mass": { "name": "Körperzellmasse" },
         "body_fat": { "name": "Körperfett" },
         "body_score": { "name": "Körperbewertung" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/en.json
+++ b/custom_components/bodymiscale/translations/en.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Age" },
         "basal_metabolism": { "name": "Basal metabolism" },
+        "bcm": { "name": "Body cell mass" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI label",
@@ -128,7 +129,6 @@
             "underweight": "Underweight"
           }
         },
-        "body_cell_mass": { "name": "Body cell mass" },
         "body_fat": { "name": "Body fat" },
         "body_score": { "name": "Body score" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/es.json
+++ b/custom_components/bodymiscale/translations/es.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Edad" },
         "basal_metabolism": { "name": "Metabolismo basal" },
+        "bcm": { "name": "Masa celular corporal" },
         "bmi": { "name": "IMC" },
         "bmi_label": {
           "name": "Clasificación IMC",
@@ -128,7 +129,6 @@
             "underweight": "Bajo peso"
           }
         },
-        "body_cell_mass": { "name": "Masa celular corporal" },
         "body_fat": { "name": "Grasa corporal" },
         "body_score": { "name": "Puntuación corporal" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/fr.json
+++ b/custom_components/bodymiscale/translations/fr.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Âge" },
         "basal_metabolism": { "name": "Métabolisme de base" },
+        "bcm": { "name": "Masse cellulaire corporelle" },
         "bmi": { "name": "IMC" },
         "bmi_label": {
           "name": "Classification IMC",
@@ -128,7 +129,6 @@
             "underweight": "Insuffisance pondérale"
           }
         },
-        "body_cell_mass": { "name": "Masse cellulaire corporelle" },
         "body_fat": { "name": "Masse grasse" },
         "body_score": { "name": "Score corporel" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/it.json
+++ b/custom_components/bodymiscale/translations/it.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Età" },
         "basal_metabolism": { "name": "Metabolismo basale" },
+        "bcm": { "name": "Massa cellulare corporea" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "Categoria BMI",
@@ -128,7 +129,6 @@
             "underweight": "Sottopeso"
           }
         },
-        "body_cell_mass": { "name": "Massa cellulare corporea" },
         "body_fat": { "name": "Massa grassa" },
         "body_score": { "name": "Punteggio corpo" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/nl.json
+++ b/custom_components/bodymiscale/translations/nl.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Leeftijd" },
         "basal_metabolism": { "name": "Basaal metabolisme" },
+        "bcm": { "name": "Lichaamscelmassa" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI-label",
@@ -128,7 +129,6 @@
             "underweight": "Ondergewicht"
           }
         },
-        "body_cell_mass": { "name": "Lichaamscelmassa" },
         "body_fat": { "name": "Lichaamsvet" },
         "body_score": { "name": "Lichaamsscore" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/pl.json
+++ b/custom_components/bodymiscale/translations/pl.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Wiek" },
         "basal_metabolism": { "name": "Podstawowa przemiana materii" },
+        "bcm": { "name": "Masa komórkowa ciała" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "Klasyfikacja BMI",
@@ -128,7 +129,6 @@
             "underweight": "Niedowaga"
           }
         },
-        "body_cell_mass": { "name": "Masa komórkowa ciała" },
         "body_fat": { "name": "Tkanka tłuszczowa" },
         "body_score": { "name": "Ocena sylwetki" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/pt-BR.json
+++ b/custom_components/bodymiscale/translations/pt-BR.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Idade" },
         "basal_metabolism": { "name": "Metabolismo basal" },
+        "bcm": { "name": "Massa celular corporal" },
         "bmi": { "name": "IMC" },
         "bmi_label": {
           "name": "Classificação do IMC",
@@ -128,7 +129,6 @@
             "underweight": "Abaixo do peso"
           }
         },
-        "body_cell_mass": { "name": "Massa celular corporal" },
         "body_fat": { "name": "Gordura corporal" },
         "body_score": { "name": "Pontuação corporal" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/ro.json
+++ b/custom_components/bodymiscale/translations/ro.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Vârstă" },
         "basal_metabolism": { "name": "Metabolism bazal" },
+        "bcm": { "name": "Masă celulară corporală" },
         "bmi": { "name": "IMC" },
         "bmi_label": {
           "name": "Clasificare IMC",
@@ -128,7 +129,6 @@
             "underweight": "Subponderal"
           }
         },
-        "body_cell_mass": { "name": "Masă celulară corporală" },
         "body_fat": { "name": "Grăsime corporală" },
         "body_score": { "name": "Scor corporal" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/ru.json
+++ b/custom_components/bodymiscale/translations/ru.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Возраст" },
         "basal_metabolism": { "name": "Базальный метаболизм" },
+        "bcm": { "name": "Масса клеток тела" },
         "bmi": { "name": "ИМТ" },
         "bmi_label": {
           "name": "Категория ИМТ",
@@ -128,7 +129,6 @@
             "underweight": "Дефицит массы тела"
           }
         },
-        "body_cell_mass": { "name": "Масса клеток тела" },
         "body_fat": { "name": "Жировая масса" },
         "body_score": { "name": "Оценка тела" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/sk.json
+++ b/custom_components/bodymiscale/translations/sk.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "Vek" },
         "basal_metabolism": { "name": "Bazálny metabolizmus" },
+        "bcm": { "name": "Bunková hmota tela" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "Klasifikácia BMI",
@@ -128,7 +129,6 @@
             "underweight": "Podváha"
           }
         },
-        "body_cell_mass": { "name": "Bunková hmota tela" },
         "body_fat": { "name": "Telesný tuk" },
         "body_score": { "name": "Skóre tela" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/zh-Hans.json
+++ b/custom_components/bodymiscale/translations/zh-Hans.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "年龄" },
         "basal_metabolism": { "name": "基础代谢" },
+        "bcm": { "name": "体细胞量" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI 状态",
@@ -128,7 +129,6 @@
             "underweight": "偏瘦"
           }
         },
-        "body_cell_mass": { "name": "体细胞量" },
         "body_fat": { "name": "体脂率" },
         "body_score": { "name": "身体评分" },
         "body_type": {

--- a/custom_components/bodymiscale/translations/zh-Hant.json
+++ b/custom_components/bodymiscale/translations/zh-Hant.json
@@ -114,6 +114,7 @@
       "state_attributes": {
         "age": { "name": "年齡" },
         "basal_metabolism": { "name": "基礎代謝" },
+        "bcm": { "name": "體細胞量" },
         "bmi": { "name": "BMI" },
         "bmi_label": {
           "name": "BMI 狀態",
@@ -128,7 +129,6 @@
             "underweight": "體重不足"
           }
         },
-        "body_cell_mass": { "name": "體細胞量" },
         "body_fat": { "name": "體脂率" },
         "body_score": { "name": "身體評分" },
         "body_type": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.5.5"
+version = "2026.5.6"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## 2026.5.6

### 🔧 Bug fixes

- Refactored metric recalculation to use topological ordering — all derived
  metrics are now computed in a single deterministic pass (BMI → LBM →
  FAT_PERCENTAGE → ... → BODY_SCORE), eliminating redundant cascade
  recalculations.
- Fixed double/redundant recalculations when weight and impedance arrive as
  separate state updates — a `_settling` flag now blocks intermediate
  recalculations until the debounce window elapses. A 5-second debounce
  (`RECALCULATION_DEBOUNCE` in `const.py`) ensures all sensors (weight,
  impedance_low, impedance_high) have settled before the single recalculation
  fires.
  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
- Fixed `last_measurement_time` updating twice per measurement cycle (once on
  weight, once on impedance) — timestamp is now stamped once in
  `_on_debounce_elapsed` after all sensors have settled.
  Closes [#378](https://github.com/dckiller51/bodymiscale/issues/378).
- Fixed renamed `bone_cell_mass` to `bcm` in attributes to match the
  bodymiscale component attribute name.