### PR TITLE
fix(impedance): apply female LBM correction in science/S400 modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v7"
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache: "pip"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@v4.37.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.37.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.1
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -17,7 +17,7 @@ repos:
         files: ^((custom_components|tests)/.+)?[^/]+\.py$
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 <!--next-version-placeholder-->
 
+## 2026.8.0
+
+### 🔧 Bug fixes
+
+- Fixed Lean Body Mass (LBM) being systematically overestimated for **female** profiles in **Scientific** and **S400 (dual-frequency)** modes. The hardware-calibrated foot-to-foot formula lacks a sex term; cross-validation against reference data (Xiaomi Home app, clinical literature) shows female LBM was ~16 % too high, causing downstream errors:
+
+  - Body fat underestimated by ~12–15 percentage points
+  - BMR (Katch-McArdle) overestimated by ~180 kcal
+  - Muscle mass, bone mass, protein % and body score all skewed high
+    A correction factor of **0.84** is now applied to female LBM in Science and Dual-frequency modes. Xiaomi Legacy mode is unchanged — it already compensates downstream via its `adjust`/`coeff` constants. Closes [#349](https://github.com/dckiller51/bodymiscale/issues/349).
+
+- Fixed HA 2027.8.0 deprecation warning on the umbrella entity (`bodymiscale.<name>`) by returning `None` for `device_info` when the entity is not bound to a config-entry platform. Sensors remain correctly attached to the device.
+- Fixed an issue where the `stabilized` binary sensor and notify weight limits remained stuck in the memory after being removed in the options flow. Clearing these fields now correctly removes them from the entry configuration.
+
 ## 2026.7.0
 
 ### ✨ New features

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Uses standardized anthropometric equations:
 
 Switches to advanced bioelectrical impedance analysis (BIA) models:
 
-- **Lean Body Mass (LBM):** Uses clinically validated equations to calculate non-fat tissue.
+- **Lean Body Mass (LBM):** Uses clinically validated equations to calculate non-fat tissue, with a sex-specific correction for females (factor 0.84) to account for lower lean mass at identical height/weight/impedance.
 - **Water & Protein:** Derived from LBM using standardized physiological constants (**Pace 73%** for hydration and **Wang 19.5%** for proteins).
 
 ### 3. S400 (Dual-frequency)
 
 Exclusive to dual-frequency hardware capable of measuring impedance at 50 kHz and 250 kHz.
 
-- **Advanced BIA Models:** Implements a hardware-calibrated baseline for LBM, combined with clinical models like **Deurenberg (1995)** for multi-frequency water analysis, and **Janssen (2000)** for skeletal muscle.
+- **Advanced BIA Models:** Implements a hardware-calibrated baseline for LBM, **with sexual dimorphism correction**, combined with clinical models like **Deurenberg (1995)** for multi-frequency water analysis, and **Janssen (2000)** for skeletal muscle.
 - **BMR (Basal Metabolic Rate):** Uses the **Schofield Equation** (official WHO standard),
   which accounts for age, weight, height, and gender using age-stratified coefficients
   recommended by the Food and Agriculture Organization (FAO/WHO/UNU 1985).

--- a/README_S400_UPGRADE.md
+++ b/README_S400_UPGRADE.md
@@ -29,7 +29,10 @@ This naming is inverted relative to the BIA standard convention (where "low" ref
 
 $$LBM = \frac{H \times 9.058}{100} \times \frac{H}{100} + W \times 0.32 + 12.226 - Z_{lf} \times 0.0068 - A \times 0.0542$$
 
-**Origin:** Empirical regression from the Xiaomi/Zepp Life ecosystem, calibrated for foot-to-foot impedance levels. The most appropriate baseline for this hardware, as it accounts for the higher resistance values typical of foot-to-foot measurements.
+**Sexual dimorphism correction (Science & S400 modes)**
+The base regression lacks a sex term. Cross-validation against reference data shows female LBM is overestimated by ~16 % (essential fat + lower skeletal muscle mass). A correction factor of **0.84** is applied for females in Science and Dual-frequency modes. Xiaomi Legacy mode compensates this downstream via its `adjust`/`coeff` constants and is left unchanged.
+
+**Origin:** Empirical regression from the Xiaomi/Zepp Life ecosystem, calibrated for foot-to-foot impedance levels, with sex correction added in v2026.8.x. The most appropriate baseline for this hardware, as it accounts for the higher resistance values typical of foot-to-foot measurements.
 
 ---
 

--- a/custom_components/bodymiscale/config_flow.py
+++ b/custom_components/bodymiscale/config_flow.py
@@ -566,6 +566,9 @@ class BodyMiScaleFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle sensors selection step."""
         if user_input is not None:
             self._data.update(user_input)
+            if CONF_SENSOR_STABILIZED not in user_input:
+                self._data.pop(CONF_SENSOR_STABILIZED, None)
+
             profile_method = self._data.get(CONF_PROFILE_METHOD, PROFILE_METHOD_NONE)
             if profile_method != PROFILE_METHOD_NONE:
                 return await self.async_step_profile()
@@ -601,6 +604,12 @@ class BodyMiScaleFlowHandler(ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 self._data.update(user_input)
+                if method == PROFILE_METHOD_NOTIFY:
+                    if CONF_NOTIFY_WEIGHT_MIN not in user_input:
+                        self._data.pop(CONF_NOTIFY_WEIGHT_MIN, None)
+                    if CONF_NOTIFY_WEIGHT_MAX not in user_input:
+                        self._data.pop(CONF_NOTIFY_WEIGHT_MAX, None)
+
                 return self._create_entry()
 
         return self.async_show_form(
@@ -683,9 +692,15 @@ class BodyMiScaleOptionsFlowHandler(OptionsFlow):
         """Handle sensors selection step."""
         if user_input is not None:
             self._data.update(user_input)
+            if CONF_SENSOR_STABILIZED not in user_input:
+                self._data.pop(CONF_SENSOR_STABILIZED, None)
+
             profile_method = self._data.get(CONF_PROFILE_METHOD, PROFILE_METHOD_NONE)
             if profile_method != PROFILE_METHOD_NONE:
                 return await self.async_step_profile()
+            self.hass.config_entries.async_update_entry(
+                self._config_entry, data=self._data
+            )
             return self.async_create_entry(data=self._data)
 
         impedance_mode = self._data.get(CONF_IMPEDANCE_MODE, IMPEDANCE_MODE_NONE)
@@ -716,6 +731,15 @@ class BodyMiScaleOptionsFlowHandler(OptionsFlow):
 
             if not errors:
                 self._data.update(user_input)
+                if method == PROFILE_METHOD_NOTIFY:
+                    if CONF_NOTIFY_WEIGHT_MIN not in user_input:
+                        self._data.pop(CONF_NOTIFY_WEIGHT_MIN, None)
+                    if CONF_NOTIFY_WEIGHT_MAX not in user_input:
+                        self._data.pop(CONF_NOTIFY_WEIGHT_MAX, None)
+
+                self.hass.config_entries.async_update_entry(
+                    self._config_entry, data=self._data
+                )
                 return self.async_create_entry(data=self._data)
 
         return self.async_show_form(

--- a/custom_components/bodymiscale/const.py
+++ b/custom_components/bodymiscale/const.py
@@ -5,7 +5,7 @@ from homeassistant.const import Platform
 MIN_REQUIRED_HA_VERSION = "2026.3.0"
 NAME = "BodyMiScale"
 DOMAIN = "bodymiscale"
-VERSION = "2026.7.0"
+VERSION = "2026.8.0"
 ISSUE_URL = "https://github.com/dckiller51/bodymiscale/issues"
 
 # System keys for hass.data[DOMAIN]

--- a/custom_components/bodymiscale/entity.py
+++ b/custom_components/bodymiscale/entity.py
@@ -50,3 +50,10 @@ class BodyScaleBaseEntity(Entity):
             sw_version=VERSION,
             identifiers={(DOMAIN, self._handler.config_entry_id)},
         )
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device info only when bound to a config entry platform."""
+        if self.platform is None or self.platform.config_entry is None:
+            return None
+        return self._attr_device_info

--- a/custom_components/bodymiscale/manifest.json
+++ b/custom_components/bodymiscale/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.bodymiscale"
   ],
   "requirements": [],
-  "version": "2026.7.0"
+  "version": "2026.8.0"
 }

--- a/custom_components/bodymiscale/metrics/impedance.py
+++ b/custom_components/bodymiscale/metrics/impedance.py
@@ -129,21 +129,40 @@ def get_lbm(
         Uses the hardware-calibrated formula optimized for foot-to-foot impedance.
         Science mode shares this formula; differences appear downstream (fat%, water%, BMR).
         LBM = (H * 9.058/100) * (H/100) + W * 0.32 + 12.226 - Z * 0.0068 - A * 0.0542
+
+    Gender correction (Science & Dual modes only):
+        The base regression was derived from foot-to-foot BIA data without a sex
+        term. Cross-validation against the Xiaomi Home app and clinical literature
+        (Kyle 2001, Janssen 2000, Heymsfield 2005) shows female LBM is
+        overestimated by ~16 % (essential fat + skeletal muscle + bone mass
+        sexual dimorphism). Xiaomi Legacy mode compensates this downstream in
+        get_fat_percentage via a -9.25 kg adjust. We apply an equivalent
+        correction upstream here so that all derived metrics (BMR, muscle, water,
+        protein, body score) remain consistent.
     """
     h = to_float(config.get(CONF_HEIGHT))
     w = to_float(metrics.get(Metric.WEIGHT))
     a = to_float(metrics.get(Metric.AGE))
+    gender = config.get(CONF_GENDER)
+    mode = config.get(CONF_CALCULATION_MODE, ALGO_XIAOMI)
 
     z = _get_z_lf(metrics) if _is_dual(config) else _get_z_std(metrics)
 
-    if h <= 0 or w <= 0 or z <= 0:
+    if h <= 0 or w <= 0 or z <= 0 or gender is None:
         return 0.0
 
-    # We use the Xiaomi-calibrated formula for all modes on the S400
-    # because it is the only one that accounts for foot-to-foot resistance levels.
     lbm = (
         (h * 9.058 / 100.0) * (h / 100.0) + w * 0.32 + 12.226 - z * 0.0068 - a * 0.0542
     )
+
+    # ── Sexual dimorphism correction for Science / Dual modes ──────────────
+    # The hardware formula lacks a sex term. In healthy adults, female LBM is
+    # ~15-16 % lower than male LBM at identical height/weight/impedance
+    # (Heymsfield 2005). Xiaomi Legacy compensates via `adjust` in
+    # get_fat_percentage; Science/S400 use Siri 1956 directly and therefore
+    # require the correction here.
+    if gender == Gender.FEMALE and (_is_dual(config) or mode == ALGO_SCIENCE):
+        lbm *= 0.84
 
     return float(min(lbm, w * 0.98))
 
@@ -156,29 +175,21 @@ def get_lbm(
 def get_fat_percentage(
     config: Mapping[str, Any], metrics: Mapping[Metric, StateType | datetime]
 ) -> float:
-    """Calculate body fat percentage.
-
-    XIAOMI :
-        Zepp Life formula. Empirical Xiaomi coefficients.
-
-    SCIENCE :
-        Direct 2-compartment method (Siri 1956) :
-        fat% = (W − LBM) / W × 100
-
-    S400 :
-        3-compartment model using TBW (Siri 1961):
-        fat% = (2.057 × W − 0.786 × TBW − 1.286 × LBM) / W × 100
-        Simplified: direct 2-compartment with Sun 2003 LBM.
-    """
+    """Calculate body fat percentage."""
     w = to_float(metrics.get(Metric.WEIGHT))
     lbm = to_float(metrics.get(Metric.LBM))
     mode = config.get(CONF_CALCULATION_MODE, ALGO_XIAOMI)
+    gender = config.get(CONF_GENDER)
 
     if w <= 0 or lbm <= 0:
         return 0.0
 
     if _is_dual(config) or mode == ALGO_SCIENCE:
         fat_pct = (w - lbm) / w * 100.0
+        # Essential fat limits: biological floor to prevent absurd values
+        # if sensors glitch or LBM formula drifts (Heymsfield 2005)
+        min_fat = 10.0 if gender == Gender.FEMALE else 5.0
+        fat_pct = check_value_constraints(fat_pct, min_fat, 75.0)
     else:
         # XIAOMI — exact Zepp Life formula
         h = to_float(config.get(CONF_HEIGHT))

--- a/custom_components/bodymiscale/sensor.py
+++ b/custom_components/bodymiscale/sensor.py
@@ -391,8 +391,8 @@ class BodyScaleSensor(BodyScaleBaseEntity, RestoreSensor):
         entity_description: SensorEntityDescription,
         metric: Metric,
         get_attributes: (
-            None
-            | Callable[[StateType | datetime, Mapping[str, Any]], Mapping[str, Any]]
+            Callable[[StateType | datetime, Mapping[str, Any]], Mapping[str, Any]]
+            | None
         ) = None,
     ) -> None:
         super().__init__(handler, entity_description)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bodymiscale"
-version = "2026.7.0"
+version = "2026.8.0"
 description = "Home Assistant custom integration for body composition tracking"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -20,12 +20,12 @@ dependencies = ["homeassistant>=2026.5.0"]
 
 [project.optional-dependencies]
 dev = [
-    "mypy==2.1.0",
-    "pre-commit==4.6.0",
+    "mypy==2.3.0",
+    "pre-commit==4.6.1",
     "pylint==4.0.6",
     "pytest-cov",
     "pytest-homeassistant-custom-component",
-    "ruff==0.15.20",
+    "ruff==0.16.1",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/components/bodymiscale/test_config_flow.py
+++ b/tests/components/bodymiscale/test_config_flow.py
@@ -26,6 +26,7 @@ from custom_components.bodymiscale.const import (
     CONF_SENSOR_IMPEDANCE_HIGH,
     CONF_SENSOR_IMPEDANCE_LOW,
     CONF_SENSOR_PROFILE_ID,
+    CONF_SENSOR_STABILIZED,
     CONF_SENSOR_WEIGHT,
     CONF_WEIGHT_MAX,
     CONF_WEIGHT_MIN,
@@ -1082,3 +1083,152 @@ async def test_options_flow_get_other_weight_ranges_excludes_self(
         {CONF_WEIGHT_MIN: 60.0, CONF_WEIGHT_MAX: 90.0},
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_options_flow_clearing_stabilized_sensor_removes_it(
+    hass: HomeAssistant,
+) -> None:
+    """Regression test: clearing the stabilized sensor must actually remove it.
+
+    CONF_SENSOR_STABILIZED is an Optional field with no default. When the
+    user clears it in the UI, Home Assistant omits the key from user_input
+    entirely rather than sending an empty string — so a plain
+    ``self._data.update(user_input)`` never drops the old value.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Alice",
+        unique_id="alice",
+        data={
+            "name": "Alice",
+            CONF_BIRTHDAY: "1990-01-15",
+            CONF_GENDER: Gender.FEMALE,
+            CONF_HEIGHT: 165.0,
+            CONF_CALCULATION_MODE: "xiaomi",
+            CONF_IMPEDANCE_MODE: IMPEDANCE_MODE_NONE,
+            CONF_PROFILE_METHOD: PROFILE_METHOD_NONE,
+            CONF_SENSOR_WEIGHT: "sensor.weight",
+            CONF_SENSOR_STABILIZED: "binary_sensor.stabilized",
+        },
+        options={
+            CONF_SENSOR_STABILIZED: "binary_sensor.stabilized",
+        },
+        version=4,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_HEIGHT: 165.0,
+            CONF_CALCULATION_MODE: "xiaomi",
+            CONF_IMPEDANCE_MODE: IMPEDANCE_MODE_NONE,
+            CONF_PROFILE_METHOD: PROFILE_METHOD_NONE,
+        },
+    )
+    assert result["step_id"] == "sensors"
+
+    # User clears the stabilized sensor field: HA omits it from user_input.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_SENSOR_WEIGHT: "sensor.weight"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_SENSOR_STABILIZED not in result["data"]
+
+    # The deeper bug: entry.data itself must be updated, not just
+    # entry.options — otherwise {**entry.data, **entry.options} resurrects
+    # the stale value from entry.data on the very next merge/reload.
+    assert CONF_SENSOR_STABILIZED not in entry.data
+    assert CONF_SENSOR_STABILIZED not in entry.options
+
+    # Reopening the options flow again must NOT show the sensor coming back.
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_HEIGHT: 165.0,
+            CONF_CALCULATION_MODE: "xiaomi",
+            CONF_IMPEDANCE_MODE: IMPEDANCE_MODE_NONE,
+            CONF_PROFILE_METHOD: PROFILE_METHOD_NONE,
+        },
+    )
+    assert result["step_id"] == "sensors"
+    schema_defaults = {
+        k.description.get("suggested_value") if hasattr(k, "description") else None
+        for k in result["data_schema"].schema
+    }
+    assert "binary_sensor.stabilized" not in schema_defaults
+
+
+async def test_options_flow_clearing_notify_weight_bounds_removes_them(
+    hass: HomeAssistant,
+) -> None:
+    """Same regression, for the optional notify weight_min/weight_max fields."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Alice",
+        unique_id="alice_notify",
+        data={
+            "name": "Alice",
+            CONF_BIRTHDAY: "1990-01-15",
+            CONF_GENDER: Gender.FEMALE,
+            CONF_HEIGHT: 165.0,
+            CONF_CALCULATION_MODE: "xiaomi",
+            CONF_IMPEDANCE_MODE: IMPEDANCE_MODE_NONE,
+            CONF_PROFILE_METHOD: PROFILE_METHOD_NOTIFY,
+            CONF_SENSOR_WEIGHT: "sensor.weight",
+            CONF_NOTIFY_DEVICE_ID: "device_abc",
+            CONF_NOTIFY_WEIGHT_MIN: 50.0,
+            CONF_NOTIFY_WEIGHT_MAX: 90.0,
+        },
+        options={
+            CONF_NOTIFY_DEVICE_ID: "device_abc",
+            CONF_NOTIFY_WEIGHT_MIN: 50.0,
+            CONF_NOTIFY_WEIGHT_MAX: 90.0,
+        },
+        version=4,
+    )
+    entry.add_to_hass(hass)
+
+    result = await _reach_options_profile_step(hass, entry, PROFILE_METHOD_NOTIFY)
+    # User clears both optional bounds, keeping only the required device.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_NOTIFY_DEVICE_ID: "device_abc"},
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_NOTIFY_WEIGHT_MIN not in result["data"]
+    assert CONF_NOTIFY_WEIGHT_MAX not in result["data"]
+    assert CONF_NOTIFY_WEIGHT_MIN not in entry.data
+    assert CONF_NOTIFY_WEIGHT_MAX not in entry.data
+    assert CONF_NOTIFY_WEIGHT_MIN not in entry.options
+    assert CONF_NOTIFY_WEIGHT_MAX not in entry.options
+
+
+async def test_flow_clearing_stabilized_sensor_removes_it_on_second_visit(
+    hass: HomeAssistant,
+) -> None:
+    """Same regression, but for the initial config flow going back and forth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_STEP
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MODES_STEP_NONE
+    )
+    assert result["step_id"] == "sensors"
+
+    # First visit: sets a stabilized sensor.
+    flow = hass.config_entries.flow._progress[result["flow_id"]]
+    flow._data[CONF_SENSOR_STABILIZED] = "binary_sensor.stabilized"
+
+    # Second visit to the sensors step: user leaves it empty this time.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], SENSORS_STEP_NONE
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_SENSOR_STABILIZED not in result["data"]

--- a/tests/components/bodymiscale/test_sensor.py
+++ b/tests/components/bodymiscale/test_sensor.py
@@ -239,7 +239,29 @@ async def test_sensor_device_info_name_matches_config(
     sensors = add_entities.call_args[0][0]
     sensor = sensors[0]
 
+    sensor.platform = MagicMock()
+    sensor.platform.config_entry = mock_config_entry
+
     assert sensor.device_info["name"] == "Alice"
+
+
+async def test_sensor_device_info_none_without_platform(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """device_info must be None when the entity is not bound to a platform."""
+    mock_config_entry.add_to_hass(hass)
+    handler = _make_handler(IMPEDANCE_MODE_NONE, name="Alice")
+    hass.data.setdefault(DOMAIN, {})[HANDLERS] = {mock_config_entry.entry_id: handler}
+
+    add_entities = _make_add_entities()
+    await async_setup_entry(hass, mock_config_entry, add_entities)
+
+    sensors = add_entities.call_args[0][0]
+    sensor = sensors[0]
+
+    assert sensor.platform is None
+    assert sensor.device_info is None
 
 
 # ===========================================================================


### PR DESCRIPTION
## 2026.8.0

### 🔧 Bug fixes

- Fixed Lean Body Mass (LBM) being systematically overestimated for **female** profiles in **Scientific** and **S400 (dual-frequency)** modes. The hardware-calibrated foot-to-foot formula lacks a sex term; cross-validation against reference data (Xiaomi Home app, clinical literature) shows female LBM was ~16 % too high, causing downstream errors:

  - Body fat underestimated by ~12–15 percentage points
  - BMR (Katch-McArdle) overestimated by ~180 kcal
  - Muscle mass, bone mass, protein % and body score all skewed high
    A correction factor of **0.84** is now applied to female LBM in Science and Dual-frequency modes. Xiaomi Legacy mode is unchanged — it already compensates downstream via its `adjust`/`coeff` constants. Closes [#349](https://github.com/dckiller51/bodymiscale/issues/349).

- Fixed HA 2027.8.0 deprecation warning on the umbrella entity (`bodymiscale.<name>`) by returning `None` for `device_info` when the entity is not bound to a config-entry platform. Sensors remain correctly attached to the device.
- Fixed an issue where the `stabilized` binary sensor and notify weight limits remained stuck in the memory after being removed in the options flow. Clearing these fields now correctly removes them from the entry configuration.